### PR TITLE
fix: bad encoded params

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,7 +74,8 @@ module ApplicationHelper
   def filter_badge(label: nil, model: nil, filter_by: nil, color: nil, title: nil)
     if model.present?
       query_string = build_query_string(toggle_filter(filter_by, label))
-      url = "/#{model}?#{query_string}"
+      url = "/#{model}"
+      url << "?#{query_string}" if query_string.present?
     end
 
     applied = get_query_params[filter_by].include? label
@@ -106,6 +107,8 @@ module ApplicationHelper
     query_params = Hash.new(Array.new)
     return query_params if not URI.parse(request.fullpath).query
     CGI.parse(URI.parse(request.fullpath).query).reduce(query_params) do |acc, el|
+      return acc if el[1][0].blank?
+
       acc[el[0]] = el[1][0].split(',')
       acc
     end


### PR DESCRIPTION
As far as I can see the the bad link (https://helpwithcovid.com/projects?skill=Software&amp) isn't generated from us. I couldn't find it anyway. The user agent is a wordpress site. 
So my hunch is that another site generated that badly encoded link and people click on it.

I've pushed a fix to strip it anyway.

![image](https://user-images.githubusercontent.com/1334409/77731215-296a3980-700b-11ea-93fa-06b9ecbc7a2d.png)
