### PR TITLE
Fix project_types and skills N+1 queries on Projects#index.

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -165,7 +165,7 @@ class ProjectsController < ApplicationController
         @projects = @projects.order('highlight DESC, COUNT(volunteers.id) DESC, created_at DESC')
       end
 
-      @projects.includes(:project_types, :skills)
+      @projects = @projects.includes(:project_types, :skills)
     end
 
     def get_order_param

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -27,21 +27,21 @@
           <%= simple_format project.description, class: 'mb-2' %>
         </div>
       </div>
-      <% if project.project_type_list.present? || project.skill_list.present?  %>
+      <% if project.project_types.present? || project.skills.present?  %>
         <div class="flex flex-col md:flex-row items-start justify-between">
           <div class="flex flex-col  flex-1 justify-end flex-wrap mt-2">
-            <% if project.project_type_list.present? %>
+            <% if project.project_types.present? %>
               <div class="mt-2 text-sm leading-5 text-gray-500 sm:mt-0 font-bold">Helping with: </div>
               <div class="flex flex-row flex-wrap space-x-right-2 space-y-top-2">
-                <%= skill_badges project.project_type_list, limit: 3, model: 'projects', filter_by: 'project_types' %>
+                <%= skill_badges project.project_types.map(&:name), limit: 3, model: 'projects', filter_by: 'project_types' %>
               </div>
             <% end %>
           </div>
-          <% if project.skill_list.present? %>
+          <% if project.skills.present? %>
             <div class="flex flex-col md:justify-end flex-wrap mt-2">
               <div class="mt-2 text-sm md:text-right leading-5 text-gray-500 sm:mt-0 font-bold">Looking for:</div>
               <div class="flex flex-row flex-wrap md:items-end md:content-end md:justify-end space-x-right-2 md:space-x-right-0 md:space-x-left-2 space-y-top-2">
-                <%= skill_badges project.skill_list, limit: 3, color: 'blue', model: 'projects', filter_by: 'skills' %>
+                <%= skill_badges project.skills.map(&:name), limit: 3, color: 'blue', model: 'projects', filter_by: 'skills' %>
               </div>
             </div>
           <% end %>


### PR DESCRIPTION
* fixes the `.includes` in ProjectsController (AR query methods don't mutate the caller)
* prefer `foobars.map(&:name)` over `foobar_list` readers to fix N+1s (according to the PR discussions in `acts_as_taggable`, the `_list` methods don't work with preloading).

This probably won't make much of a difference, but I'd be super curious if it's noticeable!