### PR TITLE
Configuration via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ Setup the database and seed data:
 rails db:setup
 ```
 
+## Configuration
+
+The following environment variables can be set:
+
+| Environment variable  | Type of value                      | Description                                              |
+|-----------------------|------------------------------------|----------------------------------------------------------|
+| `ADMINS`              | Email addresses separated by a `,` | Gives admin permissions to the listed accounts           |
+| `EXCEPTION_NOTIFIERS` | Email addresses separated by a `,` | Sends technical exceptions to the listed email addresses |
+| `EMAIL_ADDRESS`       | Single email address               | Used to contact your team                                |
+
 ## Launch app
 
 ```

--- a/app/mailers/project_mailer.rb
+++ b/app/mailers/project_mailer.rb
@@ -8,6 +8,6 @@ class ProjectMailer < ApplicationMailer
 
   def volunteer_outreach
     @user = params[:user]
-    mail(to: @user.email, reply_to: 'helpwithcovid@gmail.com', subject: "[Help With Covid - action required] Thank you and an update")
+    mail(to: @user.email, reply_to: ENV['EMAIL_ADDRESS'], subject: "[Help With Covid - action required] Thank you and an update")
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
 
     <footer class="w-full border-t border-gray-200 px-5 py-5">
       <div class="text-center text-gray-500 text-sm">
-        <%= link_to "About HWC", about_path, class: 'text-indigo-500' %> - Email us at <%= mail_to 'helpwithcovid@gmail.com', nil, target: '_blank', class: 'text-indigo-500' %> or join the <%= link_to 'Discord', 'https://discord.gg/875AhXS', target: '_blank', class: 'text-indigo-500' %> group
+        <%= link_to "About HWC", about_path, class: 'text-indigo-500' %> - Email us at <%= mail_to ENV['EMAIL_ADDRESS'], nil, target: '_blank', class: 'text-indigo-500' %> or join the <%= link_to 'Discord', 'https://discord.gg/875AhXS', target: '_blank', class: 'text-indigo-500' %> group
       </div>
     </footer>
   </body>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -168,7 +168,7 @@
         </p>
       </div>
       <div class="flex justify-between mt-3 text-sm leading-5">
-        <%= mail_to "helpwithcovid@gmail.com", "Tell about it via email &rarr;".html_safe, subject: "[Highlight request] #{@project.name} ", encoding: "hex", target: "_blank", class: "font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:underline transition ease-in-out duration-150" %>
+        <%= mail_to ENV['EMAIL_ADDRESS'], "Tell about it via email &rarr;".html_safe, subject: "[Highlight request] #{@project.name} ", encoding: "hex", target: "_blank", class: "font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:underline transition ease-in-out duration-150" %>
         <%= link_to "javascript:void(0)", id: "disable_highlight_projects_alert", class: "font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:underline transition ease-in-out duration-150" do %>
           Don't show this again
         <% end %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -121,6 +121,6 @@ Rails.application.configure do
   email: {
     email_prefix: '[HelpWithCovid] ',
     sender_address: %{"Help With Covid" <no-reply@helpwithcovid.com>},
-    exception_recipients: %w{radu.spineanu@gmail.com}
+    exception_recipients: ENV['EXCEPTION_NOTIFIERS']&.split(',')
   }
 end

--- a/config/initializers/admins.rb
+++ b/config/initializers/admins.rb
@@ -1,6 +1,1 @@
-ADMINS = [
-  'radu.spineanu@gmail.com',
-  'liamjweld@gmail.com',
-  'joe@marsbio.vc',
-  'tinneipang@gmail.com'
-]
+ADMINS = ENV['ADMINS']&.split(',') || []


### PR DESCRIPTION
These changes allow other forks of this project to more easily adapt email addresses to their team. It allows to configure:

- the email address used as `reply-to` and which is displayed on the homepage
- the email address(es) receiving technical errors
- the accounts with admin permissions

To retain your configuration, you would need to set the following environment variables on Heroku:

| Variable | Value |
|------------|---------|
| `EMAIL_ADDRESS` | `helpwithcovid@gmail.com` |
| `EXCEPTION_NOTIFIERS` | `radu.spineanu@gmail.com` |
| `ADMINS` | `radu.spineanu@gmail.com,liamjweld@gmail.com,joe@marsbio.vc,tinneipang@gmail.com` |