### PR TITLE
Fix build by loading dotenv in test mode

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,4 @@
+# It's the same as .env.sample, but one day maybe it won't be
+EMAIL_ADDRESS='email@address.com'
+EXCEPTION_NOTIFIERS='email@address.com'
+ADMINS='email@address.com,email_2@address.com'

--- a/Gemfile
+++ b/Gemfile
@@ -89,4 +89,4 @@ gem 'actionview-encoded_mail_to', git: 'https://github.com/mirko314/actionview-e
 gem 'gravatar_image_tag'
 
 # .env
-gem 'dotenv-rails', groups: [ :development ]
+gem 'dotenv-rails', groups: [ :development, :test ]

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,10 @@ require 'action_cable/engine'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-Dotenv::Railtie.load if Rails.env == 'development'
+# Initialize dotenv before booting the main application
+if Rails.env.development? || Rails.env.test?
+  Dotenv::Railtie.load
+end
 
 module CovidVolunteers
   class Application < Rails::Application


### PR DESCRIPTION
Add `.env.test` as a copy of `.env.sample`... keeping these in sync might suck but seemed cleaner than alternatives on first glance

