### PR TITLE
Add links to the GitHub repository in the footer and /about page

### DIFF
--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -7,6 +7,10 @@
       Help With Covid is a clearing house for COVID-19 related projects and volunteers looking to help out.<br/><br/>
       It is run by a team from across the world that is passionate about helping out with the current crisis. Find us on <%= link_to 'Discord', 'https://discord.gg/8nAJfFN', target: '_blank', class: 'text-indigo-500' %> on #hwc-com-development.
     </p>
+    <p>
+      This site is open-source and we invite your contributions: 
+      <%= link_to "github.com/helpwithcovid/covid-volunteers", "https://github.com/helpwithcovid/covid-volunteers", class: 'text-indigo-500' %>
+    </p>
   </div>
 
   <div class="flex flex-col mt-6">

--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -6,9 +6,9 @@
     <p class="mt-8 text-center text-sm leading-5 text-gray-600 max-w">
       Help With Covid is a clearing house for COVID-19 related projects and volunteers looking to help out.<br/><br/>
       It is run by a team from across the world that is passionate about helping out with the current crisis. Find us on <%= link_to 'Discord', 'https://discord.gg/8nAJfFN', target: '_blank', class: 'text-indigo-500' %> on #hwc-com-development.
-    </p>
-    <p>
-      This site is open-source and we invite your contributions: 
+
+      <br /><br />
+      This site is open-source and we invite your contributions
       <%= link_to "github.com/helpwithcovid/covid-volunteers", "https://github.com/helpwithcovid/covid-volunteers", class: 'text-indigo-500' %>
     </p>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,7 +47,10 @@
 
     <footer class="w-full border-t border-gray-200 px-5 py-5">
       <div class="text-center text-gray-500 text-sm">
-        <%= link_to "About HWC", about_path, class: 'text-indigo-500' %> - Email us at <%= mail_to ENV['EMAIL_ADDRESS'], nil, target: '_blank', class: 'text-indigo-500' %> or join the <%= link_to 'Discord', 'https://discord.gg/8nAJfFN', target: '_blank', class: 'text-indigo-500' %> group
+        <%= link_to "About HWC", about_path, class: 'text-indigo-500' %> - 
+        <%= link_to "GitHub", "https://github.com/helpwithcovid/covid-volunteers", class: 'text-indigo-500' %>
+        Email us at <%= mail_to ENV['EMAIL_ADDRESS'], nil, target: '_blank', class: 'text-indigo-500' %>
+        or join the <%= link_to 'Discord', 'https://discord.gg/8nAJfFN', target: '_blank', class: 'text-indigo-500' %> group
       </div>
     </footer>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,8 +47,8 @@
 
     <footer class="w-full border-t border-gray-200 px-5 py-5">
       <div class="text-center text-gray-500 text-sm">
-        <%= link_to "About HWC", about_path, class: 'text-indigo-500' %> - 
-        <%= link_to "GitHub", "https://github.com/helpwithcovid/covid-volunteers", class: 'text-indigo-500' %>
+        <%= link_to "About HWC", about_path, class: 'text-indigo-500' %> &ndash;
+        <%= link_to "GitHub", "https://github.com/helpwithcovid/covid-volunteers", class: 'text-indigo-500' %> &ndash;
         Email us at <%= mail_to ENV['EMAIL_ADDRESS'], nil, target: '_blank', class: 'text-indigo-500' %>
         or join the <%= link_to 'Discord', 'https://discord.gg/8nAJfFN', target: '_blank', class: 'text-indigo-500' %> group
       </div>


### PR DESCRIPTION
Someone asked me for the link and I realized it's not on the site

Feedback on placement and copy welcome

Looks like this in footer:

![2020-04-01 at 15-52-23 All Projects | Help With COVID 19 - a clearing house for projects and volunteers that want to help with the COVID-19 crisis  ](https://user-images.githubusercontent.com/1903/78180484-d2140100-7430-11ea-81c4-66c18f817416.png)

And on the /about page:

![2020-04-01 at 15-52-52 Help With COVID 19 - a clearing house for projects and volunteers that want to help with the COVID-19 crisis  ](https://user-images.githubusercontent.com/1903/78180502-da6c3c00-7430-11ea-89db-f3dfc0c0ca63.png)
