### PR TITLE
Added "accepting_volunteers" checkbox to projects

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -154,6 +154,10 @@ class ProjectsController < ApplicationController
       @projects = @projects.tagged_with(applied_skills) if applied_skills.length > 0
       @projects = @projects.tagged_with(applied_project_types) if applied_project_types.length > 0
 
+      if params[:accepting_volunteers].present?
+        @projects = @projects.where(accepting_volunteers: true)
+      end
+      
       if params[:query].present?
         @projects = @projects.search(params[:query]).left_joins(:volunteers).reorder(nil).group(:id)
       else

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -71,7 +71,6 @@ class ProjectsController < ApplicationController
 
   def new
     @project = Project.new
-    @project.accepting_volunteers = true # default true
   end
 
   def create
@@ -153,10 +152,7 @@ class ProjectsController < ApplicationController
       @projects = Project
       @projects = @projects.tagged_with(applied_skills) if applied_skills.length > 0
       @projects = @projects.tagged_with(applied_project_types) if applied_project_types.length > 0
-
-      if params[:accepting_volunteers].present?
-        @projects = @projects.where(accepting_volunteers: true)
-      end
+      @projects = @projects.where(accepting_volunteers: params[:accepting_volunteers] == "1") if params[:accepting_volunteers].present?
       
       if params[:query].present?
         @projects = @projects.search(params[:query]).left_joins(:volunteers).reorder(nil).group(:id)
@@ -169,6 +165,7 @@ class ProjectsController < ApplicationController
       else
         @projects = @projects.order('highlight DESC, COUNT(volunteers.id) DESC, created_at DESC')
       end
+
 
       @projects = @projects.includes(:project_types, :skills)
     end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -71,6 +71,7 @@ class ProjectsController < ApplicationController
 
   def new
     @project = Project.new
+    @project.accepting_volunteers = true # default true
   end
 
   def create
@@ -135,7 +136,7 @@ class ProjectsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def project_params
-      params.fetch(:project, {}).permit(:name, :description, :participants, :looking_for, :contact, :location, :progress, :docs_and_demo, :number_of_volunteers, :links, :skill_list => [], :project_type_list => [])
+      params.fetch(:project, {}).permit(:name, :description, :participants, :looking_for, :contact, :location, :progress, :docs_and_demo, :accepting_volunteers, :number_of_volunteers, :links, :skill_list => [], :project_type_list => [])
     end
 
     def ensure_owner_or_admin

--- a/app/frontend/covid/covid.js
+++ b/app/frontend/covid/covid.js
@@ -1,5 +1,6 @@
 import Cookies from 'js-cookie'
 import VolunteerGroups from './volunteer_groups'
+import NewProject from './new_project'
 
 const Covid = {
   initialize() {
@@ -15,6 +16,7 @@ const Covid = {
       })
     });
     VolunteerGroups.initialize();
+    NewProject.initialize();
   },
   toggleFiltersOpen() {
     let filtersOpen;

--- a/app/frontend/covid/covid.js
+++ b/app/frontend/covid/covid.js
@@ -1,6 +1,6 @@
 import Cookies from 'js-cookie'
 import VolunteerGroups from './volunteer_groups'
-import NewProject from './new_project'
+import ProjectForm from './project_form'
 
 const Covid = {
   initialize() {
@@ -16,7 +16,7 @@ const Covid = {
       })
     });
     VolunteerGroups.initialize();
-    NewProject.initialize();
+    ProjectForm.initialize();
   },
   toggleFiltersOpen() {
     let filtersOpen;

--- a/app/frontend/covid/new_project.js
+++ b/app/frontend/covid/new_project.js
@@ -1,0 +1,27 @@
+const NewProject = {
+    initialize() {
+      $( document ).on('turbolinks:load', () => {
+        if ($('form.new_project,form.edit_project').length > 0) {
+            $('#project_accepting_volunteers').on('click', function(e){
+                NewProject.updateState();
+            });
+
+            NewProject.updateState();
+        }
+      });
+    },
+
+    updateState() {
+        if ($('#project_accepting_volunteers').is(':checked')) {
+            console.log($('.is-accepting-volunteers'));
+            $('.is-accepting-volunteers').css('display', '');
+            $('#project_looking_for').attr('required', 'required');
+        }
+        else {
+            $('.is-accepting-volunteers').css('display', 'none');
+            $('#project_looking_for').removeAttr('required');
+        }
+    }
+}
+
+export default NewProject;

--- a/app/frontend/covid/project_form.js
+++ b/app/frontend/covid/project_form.js
@@ -1,19 +1,18 @@
-const NewProject = {
+const ProjectForm = {
     initialize() {
       $( document ).on('turbolinks:load', () => {
         if ($('form.new_project,form.edit_project').length > 0) {
             $('#project_accepting_volunteers').on('click', function(e){
-                NewProject.updateState();
+                ProjectForm.updateState();
             });
 
-            NewProject.updateState();
+            ProjectForm.updateState();
         }
       });
     },
 
     updateState() {
         if ($('#project_accepting_volunteers').is(':checked')) {
-            console.log($('.is-accepting-volunteers'));
             $('.is-accepting-volunteers').css('display', '');
             $('#project_looking_for').attr('required', 'required');
         }
@@ -24,4 +23,4 @@ const NewProject = {
     }
 }
 
-export default NewProject;
+export default ProjectForm;

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -38,6 +38,7 @@ class Project < ApplicationRecord
         :progress,
         :docs_and_demo,
         :number_of_volunteers,
+        :accepting_volunteers,
         :created_at,
         :updated_at
       ],

--- a/app/views/projects/_project_form.html.erb
+++ b/app/views/projects/_project_form.html.erb
@@ -58,47 +58,6 @@
     </div>
   </div>
 
-  <div class="mt-6 sm:mt-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
-    <label for="looking_for" class="block text-sm font-medium leading-5 text-gray-700 sm:mt-px sm:pt-2">
-      What tasks need to get done?
-    </label>
-    <div class="mt-1 sm:mt-0 sm:col-span-2">
-      <div class="max-w-lg flex rounded-md shadow-sm">
-        <%= f.text_area "looking_for", rows: 3, class: "form-textarea block w-full transition duration-150 ease-in-out sm:text-sm sm:leading-5", required: true %>
-      </div>
-      <p class="mt-2 text-sm text-gray-500">Tell volunteers how they might help you. Be specific. If it's tech mention the stack.</p>
-    </div>
-  </div>
-
-  <div class="mt-6 sm:mt-5">
-    <div class="sm:border-t sm:border-gray-200 sm:pt-5">
-      <fieldset>
-        <div class="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-baseline">
-          <div>
-            <legend class="text-base leading-6 font-medium text-gray-900 sm:text-sm sm:leading-5 sm:text-gray-700">
-              Skills needed
-            </legend>
-          </div>
-          <div class="mt-4 sm:mt-0 sm:col-span-2">
-            <div class="max-w-lg">
-              <% ALL_SKILLS.each do |skill| %>
-                <div class="relative flex items-start">
-                  <div class="absolute flex items-center h-5">
-                  <%= f.check_box :skill_list, { multiple: true, class:  "form-checkbox h-4 w-4 text-indigo-600 transition duration-150 ease-in-out"}, skill, nil %>
-                  </div>
-                  <div class="pl-7 text-sm leading-5">
-                    <label for="project_skill_list_<%= skill.downcase.gsub(' & ', '__').gsub(' ', '_') %>" class="font-medium text-gray-700">
-                      <%= skill %>
-                    </label>
-                  </div>
-                </div>
-              <% end %>
-            </div>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-  </div>
 
   <div class="mt-6 sm:mt-5">
     <div class="sm:border-t sm:border-gray-200 sm:pt-5">
@@ -131,6 +90,67 @@
   </div>
 
   <div class="mt-6 sm:mt-5">
+    <div class="sm:border-t sm:border-gray-200 sm:pt-5">
+      <fieldset>
+        <div class="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-baseline">
+          <div>
+            <legend class="text-base leading-6 font-medium text-gray-900 sm:text-sm sm:leading-5 sm:text-gray-700">
+              Are you actively looking for volunteers?
+            </legend>
+          </div>
+          <div class="mt-4 sm:mt-0 sm:col-span-2">
+            <div class="max-w-lg">
+              <%= f.check_box :accepting_volunteers %>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  </div>
+
+  <div class="mt-6 sm:mt-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5 is-accepting-volunteers">
+    <label for="looking_for" class="block text-sm font-medium leading-5 text-gray-700 sm:mt-px sm:pt-2">
+      What tasks need to get done?
+    </label>
+    <div class="mt-1 sm:mt-0 sm:col-span-2">
+      <div class="max-w-lg flex rounded-md shadow-sm">
+        <%= f.text_area "looking_for", rows: 3, class: "form-textarea block w-full transition duration-150 ease-in-out sm:text-sm sm:leading-5", required: false %>
+      </div>
+      <p class="mt-2 text-sm text-gray-500">Tell volunteers how they might help you. Be specific. If it's tech mention the stack.</p>
+    </div>
+  </div>
+
+  <div class="mt-6 sm:mt-5 is-accepting-volunteers">
+    <div class="sm:border-t sm:border-gray-200 sm:pt-5">
+      <fieldset>
+        <div class="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-baseline">
+          <div>
+            <legend class="text-base leading-6 font-medium text-gray-900 sm:text-sm sm:leading-5 sm:text-gray-700">
+              Skills needed
+            </legend>
+          </div>
+          <div class="mt-4 sm:mt-0 sm:col-span-2">
+            <div class="max-w-lg">
+              <% ALL_SKILLS.each do |skill| %>
+                <div class="relative flex items-start">
+                  <div class="absolute flex items-center h-5">
+                  <%= f.check_box :skill_list, { multiple: true, class:  "form-checkbox h-4 w-4 text-indigo-600 transition duration-150 ease-in-out"}, skill, nil %>
+                  </div>
+                  <div class="pl-7 text-sm leading-5">
+                    <label for="project_skill_list_<%= skill.downcase.gsub(' & ', '__').gsub(' ', '_') %>" class="font-medium text-gray-700">
+                      <%= skill %>
+                    </label>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  </div>
+
+  <div class="mt-6 sm:mt-5 is-accepting-volunteers">
     <div class="sm:border-t sm:border-gray-200 sm:pt-5">
       <fieldset>
         <div class="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-baseline">

--- a/app/views/projects/_project_form.html.erb
+++ b/app/views/projects/_project_form.html.erb
@@ -100,7 +100,7 @@
           </div>
           <div class="mt-4 sm:mt-0 sm:col-span-2">
             <div class="max-w-lg">
-              <%= f.check_box :accepting_volunteers %>
+              <%= f.check_box :accepting_volunteers, class:  "form-checkbox h-4 w-4 text-indigo-600 transition duration-150 ease-in-out" %>
             </div>
           </div>
         </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -269,32 +269,7 @@
           </dd>
         </div>
       <% end %>
-      <div class="mt-8 sm:mt-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:border-t sm:border-gray-200 sm:px-6 sm:pt-5 sm:pb-2">
-        <dt class="text-sm leading-5 font-medium text-gray-500">
-          Tasks that need to get done
-        </dt>
-        <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
-          <%= simple_format @project.looking_for, class: 'mb-3' %>
-        </dd>
-      </div>
-      <% if @project.number_of_volunteers.present? %>
-        <div class="mt-8 sm:mt-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:border-t sm:border-gray-200 sm:px-6 sm:py-5">
-          <dt class="text-sm leading-5 font-medium text-gray-500">
-            Number of volunteers
-          </dt>
-          <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
-            <%= @project.number_of_volunteers %>
-          </dd>
-        </div>
-      <% end %>
-      <div class="mt-8 sm:mt-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:border-t sm:border-gray-200 sm:px-6 sm:py-5">
-        <dt class="text-sm leading-5 font-medium text-gray-500">
-          Location
-        </dt>
-        <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
-          <%= @project.location %>
-        </dd>
-      </div>
+      
       <% if @project.contact.present? %>
         <div class="mt-8 sm:mt-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:border-t sm:border-gray-200 sm:px-6 sm:pt-5 sm:pb-2">
           <dt class="text-sm leading-5 font-medium text-gray-500">
@@ -305,6 +280,15 @@
           </dd>
         </div>
       <% end %>
+
+      <div class="mt-8 sm:mt-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:border-t sm:border-gray-200 sm:px-6 sm:py-5">
+        <dt class="text-sm leading-5 font-medium text-gray-500">
+          Location
+        </dt>
+        <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
+          <%= @project.location %>
+        </dd>
+      </div>
 
       <% if @project.links.present? %>
         <div class="mt-8 sm:mt-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:border-t sm:border-gray-200 sm:px-6 sm:py-5">
@@ -317,15 +301,37 @@
         </div>
       <% end %>
 
-      <% if @project.skill_list.present? %>
-        <div class="mt-8 sm:mt-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:border-t sm:border-gray-200 sm:px-6 sm:py-5">
+      <% if @project.accepting_volunteers? %>
+        <div class="mt-8 sm:mt-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:border-t sm:border-gray-200 sm:px-6 sm:pt-5 sm:pb-2">
           <dt class="text-sm leading-5 font-medium text-gray-500">
-            Skills needed
+            Tasks that need to get done
           </dt>
-          <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2 flex content-center flex-wrap space-y-bottom-2 -mb-2 space-x-right-2">
-            <%= skill_badges @project.skill_list, color: 'blue', model: 'projects', filter_by: 'skills' %>
+          <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
+            <%= simple_format @project.looking_for, class: 'mb-3' %>
           </dd>
         </div>
+        
+        <% if @project.number_of_volunteers.present? %>
+          <div class="mt-8 sm:mt-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:border-t sm:border-gray-200 sm:px-6 sm:py-5">
+            <dt class="text-sm leading-5 font-medium text-gray-500">
+              Number of volunteers needed
+            </dt>
+            <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
+              <%= @project.number_of_volunteers %>
+            </dd>
+          </div>
+        <% end %>
+
+        <% if @project.skill_list.present? %>
+          <div class="mt-8 sm:mt-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:border-t sm:border-gray-200 sm:px-6 sm:py-5">
+            <dt class="text-sm leading-5 font-medium text-gray-500">
+              Skills needed
+            </dt>
+            <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2 flex content-center flex-wrap space-y-bottom-2 -mb-2 space-x-right-2">
+              <%= skill_badges @project.skill_list, color: 'blue', model: 'projects', filter_by: 'skills' %>
+            </dd>
+          </div>
+        <% end %>
       <% end %>
 
       <% if @project.project_type_list.present? %>

--- a/db/migrate/20200401143158_accepting_volunteers.rb
+++ b/db/migrate/20200401143158_accepting_volunteers.rb
@@ -1,0 +1,5 @@
+class AcceptingVolunteers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :projects, :accepting_volunteers, :boolean
+  end
+end

--- a/db/migrate/20200401143158_accepting_volunteers.rb
+++ b/db/migrate/20200401143158_accepting_volunteers.rb
@@ -1,5 +1,5 @@
 class AcceptingVolunteers < ActiveRecord::Migration[6.0]
   def change
-    add_column :projects, :accepting_volunteers, :boolean
+    add_column :projects, :accepting_volunteers, :boolean, default: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 2020_04_01_143158) do
     t.string "docs_and_demo", default: "", null: false
     t.string "number_of_volunteers", default: "", null: false
     t.string "links", default: ""
-    t.boolean "accepting_volunteers"
+    t.boolean "accepting_volunteers", default: true
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_28_073356) do
+ActiveRecord::Schema.define(version: 2020_04_01_143158) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2020_03_28_073356) do
     t.string "docs_and_demo", default: "", null: false
     t.string "number_of_volunteers", default: "", null: false
     t.string "links", default: ""
+    t.boolean "accepting_volunteers"
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -23,10 +23,20 @@ RSpec.describe ProjectsController, type: :controller do
       expect(json[0]["to_param"]).to eq(project.to_param)
     end
 
-    it 'filters by accepting_volunteers' do
-      get :index, params: { accepting_volunteers: true }
+    it 'filters by ?accepting_volunteers=0' do
+      no_volunteers_project = FactoryBot.create(:project, user: user, accepting_volunteers: false)
+      get :index, params: { accepting_volunteers: "0" }
       expect(response).to be_successful
+      expect(assigns(:projects)).to include(no_volunteers_project)
       expect(assigns(:projects)).to_not include(project)
+    end 
+
+    it 'filters by ?accepting_volunteers=1' do
+      no_volunteers_project = FactoryBot.create(:project, user: user, accepting_volunteers: false)
+      get :index, params: { accepting_volunteers: "1" }
+      expect(response).to be_successful
+      expect(assigns(:projects)).to_not include(no_volunteers_project)
+      expect(assigns(:projects)).to include(project)
     end 
   end
 
@@ -78,12 +88,6 @@ RSpec.describe ProjectsController, type: :controller do
       expect(response).to be_successful
     end
 
-    it 'defaults new projects with accepting_volunteers=true' do
-      sign_in user
-      get :new
-      expect(assigns(:project).accepting_volunteers).to eq(true)
-    end
-
     it 'redirects you if signed out' do
       get :new
       expect(response).to_not be_successful
@@ -113,10 +117,10 @@ RSpec.describe ProjectsController, type: :controller do
   describe 'PUT #update' do
     it 'updating accepting_volunteers works' do
       sign_in user
-      expect(project.accepting_volunteers).to_not eq(true)
-      put :update, params: { id: project.id, project: { accepting_volunteers: true } }
+      expect(project.accepting_volunteers).to eq(true)
+      put :update, params: { id: project.id, project: { accepting_volunteers: false } }
       expect(response).to be_redirect
-      expect(assigns(:project).accepting_volunteers).to eq(true)
+      expect(assigns(:project).accepting_volunteers).to eq(false)
     end
   end
 

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -39,21 +39,61 @@ RSpec.describe ProjectsController, type: :controller do
       expect(json["name"]).to eq(project.name)
       expect(json["description"]).to eq(project.description)
       expect(json["location"]).to eq(project.location)
+      expect(json["accepting_volunteers"]).to eq(project.accepting_volunteers)
       expect(json["to_param"]).to eq(project.to_param)
     end
+
+    describe 'Volunteering' do
+      it 'hide volunteer info' do
+        project.number_of_volunteers = "100";
+        project.accepting_volunteers = false
+        project.save
+        get :show, params: { id: project.to_param }
+        expect(response).to be_successful
+        expect(response.body).to_not include("Number of volunteers")
+      end
+
+      it 'show volunteer info' do
+        project.number_of_volunteers = "100";
+        project.accepting_volunteers = true
+        project.save
+        get :show, params: { id: project.to_param }
+        expect(response).to be_successful
+        expect(response.body).to include("Number of volunteers")
+      end
+    end
+
   end
 
   describe 'GET #new' do
     it 'works' do
-      pending 'TODO'
-      fail
+      sign_in user
+      get :new
+      expect(response).to be_successful
+    end
+
+    it 'defaults new projects with accepting_volunteers=true' do
+      sign_in user
+      get :new
+      expect(assigns(:project).accepting_volunteers).to eq(true)
+    end
+
+    it 'redirects you if signed out' do
+      get :new
+      expect(response).to_not be_successful
     end
   end
 
   describe 'GET #edit' do
     it 'works' do
-      pending 'TODO'
-      fail
+      sign_in user
+      get :edit, params: { id: project.id }
+      expect(response).to be_successful
+    end
+
+    it 'fails if not signed in' do
+      get :edit, params: { id: project.id }
+      expect(response).to_not be_successful
     end
   end
 
@@ -65,12 +105,14 @@ RSpec.describe ProjectsController, type: :controller do
   end
 
   describe 'PUT #update' do
-    it 'works' do
-      pending 'TODO'
-      fail
+    it 'updating accepting_volunteers works' do
+      sign_in user
+      expect(project.accepting_volunteers).to_not eq(true)
+      put :update, params: { id: project.id, project: { accepting_volunteers: true } }
+      expect(response).to be_redirect
+      expect(assigns(:project).accepting_volunteers).to eq(true)
     end
   end
-
 
   describe 'DELETE #destroy' do
     it 'works' do

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe ProjectsController, type: :controller do
       expect(json[0]["location"]).to eq(project.location)
       expect(json[0]["to_param"]).to eq(project.to_param)
     end
+
+    it 'filters by accepting_volunteers' do
+      get :index, params: { accepting_volunteers: true }
+      expect(response).to be_successful
+      expect(assigns(:projects)).to_not include(project)
+    end 
   end
 
   describe 'GET #show' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -11,4 +11,9 @@ RSpec.describe Project, type: :model do
     project = FactoryBot.build(:project, user: nil)
     expect(project).to_not be_valid
   end
+
+  it 'accepting_volunteers defaults true' do
+    project = FactoryBot.build(:project, user: nil)
+    expect(project.accepting_volunteers).to eq(true)
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,5 +64,7 @@ RSpec.configure do |config|
   # Devise/Warden
   config.include Devise::Test::ControllerHelpers, :type => :controller
   config.include Warden::Test::Helpers
+  config.include Devise::Test::IntegrationHelpers, :type => :request
 
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
Started a PR for #107 

Changelog
- Added `accepting_volunteers` boolean 
- Added checkbox to `new/edit` forms. Also added JS to hide relevant fields if you arent actually needing volunteers.
- Same fields get hidden on `show` page if you uncheck volunteers.
- Added query string filter for `project#index`. Will expose in the view at some later point.
- Wrote tests for all of the above and added some missing specs

### Collapsed on edit/new
<img width="971" alt="image" src="https://user-images.githubusercontent.com/156097/78186954-96caff80-743b-11ea-86eb-77227bd058f7.png">

### Expanded 
<img width="946" alt="image" src="https://user-images.githubusercontent.com/156097/78186979-a34f5800-743b-11ea-92d8-9e2b8ca18675.png">
