### PR TITLE
Accepting volunteers radio buttons

### DIFF
--- a/app/frontend/covid/project_form.js
+++ b/app/frontend/covid/project_form.js
@@ -1,8 +1,8 @@
 const ProjectForm = {
     initialize() {
-      $( document ).on('turbolinks:load', () => {
+      $(document).on('turbolinks:load', () => {
         if ($('form.new_project,form.edit_project').length > 0) {
-            $('#project_accepting_volunteers').on('click', function(e){
+            $('input[name="project[accepting_volunteers]"]').on('click', function(e) {
                 ProjectForm.updateState();
             });
 
@@ -12,7 +12,7 @@ const ProjectForm = {
     },
 
     updateState() {
-        if ($('#project_accepting_volunteers').is(':checked')) {
+        if ($('input[name="project[accepting_volunteers]"]:checked').val() == 'true') {
             $('.is-accepting-volunteers').css('display', '');
             $('#project_looking_for').attr('required', 'required');
         }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,6 +3,8 @@ class Project < ApplicationRecord
 
   include PgSearch::Model
 
+  validates :name, presence: true
+  
   has_many :volunteers, dependent: :destroy
   has_many :volunteered_users, through: :volunteers, source: :user, dependent: :destroy
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,12 +17,18 @@ class User < ApplicationRecord
 
   pg_search_scope :search, against: %i(name email about location level_of_availability)
 
-  def volunteered_for_project? project
+  def volunteered_for_project?(project)
     self.volunteered_projects.where(id: project.id).exists?
   end
 
   def has_complete_profile?
     self.about.present? && self.profile_links.present? && self.location.present?
+  end
+  
+  def has_correct_skills?(project)
+    project_skills = project.skills.map(&:name)
+    return true if project_skills.include?("Anything")
+    (self.skills.map(&:name) & project.skills.map(&:name)).present?
   end
 
   def is_visible_to_user?(user_trying_view)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,10 +24,10 @@ class User < ApplicationRecord
   def has_complete_profile?
     self.about.present? && self.profile_links.present? && self.location.present?
   end
-  
+
   def has_correct_skills?(project)
     project_skills = project.skills.map(&:name)
-    return true if project_skills.include?("Anything")
+    return true if project_skills.include?('Anything')
     (self.skills.map(&:name) & project.skills.map(&:name)).present?
   end
 
@@ -37,7 +37,7 @@ class User < ApplicationRecord
     return true if user_trying_view == self
 
     # Check if this user volunteered for any project by user_trying_view.
-    return self.volunteered_projects.where(user_id: user_trying_view.id).exists?
+    self.volunteered_projects.where(user_id: user_trying_view.id).exists?
   end
 
   def is_admin?
@@ -45,7 +45,7 @@ class User < ApplicationRecord
   end
 
   def to_param
-    [id, name.parameterize].join("-")
+    [id, name.parameterize].join('-')
   end
 
   def self.to_csv
@@ -55,7 +55,7 @@ class User < ApplicationRecord
       csv << attributes
 
       all.find_each do |user|
-        csv << attributes.map{ |attr| user.send(attr) }
+        csv << attributes.map { |attr| user.send(attr) }
       end
     end
   end

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -8,16 +8,18 @@
         <div class="mt-2 md:mt-0 md:ml-4 flex-shrink-0 flex">
           <% project_volunteer_class = project.volunteered_users.count > 0 ? "bg-green-100 text-green-800" : "bg-yellow-100 text-yellow-800" %>
           <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full <%= project_volunteer_class %>">
-            <% if project.volunteered_users.count == 0 %>
-              no volunteers
-            <% else %>
-              <%= pluralize(project.volunteered_users.count, 'volunteer') %>
-            <% end %>
+            <% if project.accepting_volunteers? %>
+              <% if project.volunteered_users.count == 0 %>
+                no volunteers
+              <% else %>
+                <%= pluralize(project.volunteered_users.count, 'volunteer') %>
+              <% end %>
 
-            <% if current_user.blank? %>
-              - sign up to volunteer
-            <% elsif !current_user.has_complete_profile? %>
-              - complete your profile to volunteer
+              <% if current_user.blank? %>
+                - sign up to volunteer
+              <% elsif !current_user.has_complete_profile? %>
+                - complete your profile to volunteer
+              <% end %>
             <% end %>
           </span>
         </div>

--- a/app/views/projects/_project_form.html.erb
+++ b/app/views/projects/_project_form.html.erb
@@ -97,10 +97,19 @@
             <legend class="text-base leading-6 font-medium text-gray-900 sm:text-sm sm:leading-5 sm:text-gray-700">
               Are you actively looking for volunteers?
             </legend>
+            <div class="text-sm text-gray-500">You can always change this later</div>
           </div>
           <div class="mt-4 sm:mt-0 sm:col-span-2">
             <div class="max-w-lg">
-              <%= f.check_box :accepting_volunteers, class:  "form-checkbox h-4 w-4 text-indigo-600 transition duration-150 ease-in-out" %>
+              <div class="block">
+                <%= f.radio_button :accepting_volunteers, true, checked: @project.new_record? ? true : @project.accepting_volunteers, class: "form-radio h-4 w-4 text-indigo-600 transition duration-150 ease-in-out" %>
+                <%= f.label :accepting_volunteers, "Yes - Volunteers will be able to apply.", value: "true", class: "pl-2 text-sm text-gray-700"  %>
+              </div>
+
+              <div class="block">
+                <%= f.radio_button :accepting_volunteers, false, class: "form-radio h-4 w-4 text-indigo-600 transition duration-150 ease-in-out" %>
+                <%= f.label :accepting_volunteers, "No - We have all the people and resources we need at the moment.", value: "false", class: "pl-2 text-sm text-gray-700" %>
+              </div>
             </div>
           </div>
         </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -117,17 +117,32 @@
               </span>
             <% end %>
           <% else %>
-            <%= link_to toggle_volunteer_project_path(@project), method: :post, data: { confirm: "Are you sure you want to volunteer? The project owner will be alerted." } do %>
-              <span class="ml-3 inline-flex rounded-md shadow-sm mt-4">
-                <button type="button" class="relative inline-flex items-center px-4 py-2 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:shadow-outline-indigo focus:border-indigo-700 active:bg-indigo-700">
-                  <svg class="-ml-1 mr-2 h-5 w-5 text-white" fill="currentColor" viewBox="0 0 20 20">
-                    <path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z"/>
-                  </svg>
-                  <span>
-                    Volunteer
-                  </span>
-                </button>
-              </span>
+            <% if current_user.has_correct_skills?(@project) %>
+              <%= link_to toggle_volunteer_project_path(@project), method: :post, data: { confirm: "Are you sure you want to volunteer? The project owner will be alerted." } do %>
+                <span class="ml-3 inline-flex rounded-md shadow-sm mt-4">
+                  <button id="volunteers-btn" type="button" class="relative inline-flex items-center px-4 py-2 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:shadow-outline-indigo focus:border-indigo-700 active:bg-indigo-700">
+                    <svg class="-ml-1 mr-2 h-5 w-5 text-white" fill="currentColor" viewBox="0 0 20 20">
+                      <path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z"/>
+                    </svg>
+                    <span>
+                      Volunteer
+                    </span>
+                  </button>
+                </span>
+              <% end %>
+            <% else %>
+              <%= link_to edit_user_registration_path, data: { confirm: "It looks like the skills needed for this project do not match your skillset. \n\nIf you think this is incorrect, please update your profile with one of the following skills: \n#{@project.skills.join(', ')}" } do %>
+                <span class="ml-3 inline-flex rounded-md shadow-sm mt-4">
+                  <button id="volunteers-filled-btn" type="button" class="relative inline-flex items-center px-4 py-2 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:shadow-outline-indigo focus:border-indigo-700 active:bg-indigo-700">
+                    <svg class="-ml-1 mr-2 h-5 w-5 text-white" fill="currentColor" viewBox="0 0 20 20">
+                      <path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z"/>
+                    </svg>
+                    <span>
+                      Volunteers Filled
+                    </span>
+                  </button>
+                </span>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -190,7 +190,7 @@
   <div class="bg-white mt-6 border-2 border-orange-300 bg-orange-100 shadow sm:rounded-lg" id="disable_highlight_projects_container">
     <div class="px-4 py-5 sm:p-6">
       <h3 class="text-lg leading-6 font-medium text-gray-900">
-        Validated or established project with large impact?
+        Are you a validated or established project with large impact?
       </h3>
       <div class="mt-2 text-sm leading-5 text-gray-500">
         <p>
@@ -198,7 +198,7 @@
         </p>
       </div>
       <div class="flex justify-between mt-3 text-sm leading-5">
-        <%= mail_to ENV['EMAIL_ADDRESS'], "Tell about it via email &rarr;".html_safe, subject: "[Highlight request] #{@project.name} ", encoding: "hex", target: "_blank", class: "font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:underline transition ease-in-out duration-150" %>
+        <%= mail_to ENV['EMAIL_ADDRESS'], "Tell us about your project &rarr;".html_safe, subject: "[Highlight request] #{@project.name} ", encoding: "hex", target: "_blank", class: "font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:underline transition ease-in-out duration-150" %>
         <%= link_to "javascript:void(0)", id: "disable_highlight_projects_alert", class: "font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:underline transition ease-in-out duration-150" do %>
           Don't show this again
         <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-User.create!(
+user = User.create!(
   email: 'user@gmail.com',
   name: 'Bob Smith',
   password: 'password',
@@ -17,3 +17,28 @@ User.create!(
   visibility: true,
   level_of_availability: '2-4 hours a day'
 )
+
+user2 = User.create!(
+  email: 'user2@gmail.com',
+  name: 'Jill Bob',
+  password: 'password',
+  password_confirmation: 'password',
+  about: 'about section',
+  location: 'location section',
+  profile_links: 'github.com',
+  visibility: true,
+  level_of_availability: '99-100 hours a day'
+)
+
+user3 = User.create!(email: 'user3@gmail.com', name: 'Luv2Code', password: "password", password_confirmation: "password")
+user4 = User.create!(email: 'user4@gmail.com', name: 'rspineanu', password: "password", password_confirmation: "password")
+user5 = User.create!(email: 'user5@gmail.com', name: 'cpu', password: "password", password_confirmation: "password")
+user6 = User.create!(email: 'user6@gmail.com', name: 'jamiew', password: "password", password_confirmation: "password")
+
+project1 = Project.create(user: user, name: 'Act Now Foundation - Import & distribution of 10-minute at home COVID-19 test kits', description: 'A cool description', accepting_volunteers: true)
+project1.skill_list.add('Design')
+project1.save
+
+project2 = Project.create!(user: user2, name: 'One Gazillion Masks', description: 'A cool description', accepting_volunteers: false)
+
+project1.volunteered_users << user3

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ProjectsController, type: :controller do
 
   let!(:user){ FactoryBot.create(:user) }
   let!(:project){ FactoryBot.create(:project, user: user) }
+  let(:valid_params) { { project: { name: "My Project Name" } } }
 
   describe 'GET #index' do
     it 'works' do
@@ -109,8 +110,10 @@ RSpec.describe ProjectsController, type: :controller do
 
   describe 'POST #create' do
     it 'works' do
-      pending 'TODO'
-      fail
+      sign_in user
+      post :create, params: valid_params
+      expect(assigns(:project)).to be_present 
+      expect(response).to be_redirect
     end
   end
 

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ProjectsController, type: :controller do
 
     it 'returns json' do
       get :index, format: 'json'
+      project = Project.first
       json = JSON.parse(response.body)
       expect(response).to be_successful
       expect(json[0]["name"]).to eq(project.name)
@@ -42,14 +43,15 @@ RSpec.describe ProjectsController, type: :controller do
       end 
 
       it 'hides volunteer action item' do
+        Project.update_all(accepting_volunteers: true)
         get :index
-        expect(response.body.scan('sign up to volunteer').size).to eq(1)
+        expect(response.body.scan('sign up to volunteer').size).to be > 0
       end 
 
       it 'shows volunteer action item' do
-        no_volunteers_project.update_attribute(:accepting_volunteers, true)
+        Project.update_all(accepting_volunteers: false)
         get :index
-        expect(response.body.scan('sign up to volunteer').size).to eq(2)
+        expect(response.body.scan('sign up to volunteer').size).to eq(0)
       end 
     end 
   end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe ProjectsController, type: :controller do
   render_views
 
-  let!(:user){ FactoryBot.create(:user) }
-  let!(:project){ FactoryBot.create(:project, user: user) }
-  let(:valid_params) { { project: { name: "My Project Name" } } }
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:project) { FactoryBot.create(:project, user: user) }
+  let(:valid_params) { { project: { name: 'My Project Name' } } }
 
   describe 'GET #index' do
     it 'works' do
@@ -19,41 +19,41 @@ RSpec.describe ProjectsController, type: :controller do
       project = Project.first
       json = JSON.parse(response.body)
       expect(response).to be_successful
-      expect(json[0]["name"]).to eq(project.name)
-      expect(json[0]["description"]).to eq(project.description)
-      expect(json[0]["location"]).to eq(project.location)
-      expect(json[0]["to_param"]).to eq(project.to_param)
+      expect(json[0]['name']).to eq(project.name)
+      expect(json[0]['description']).to eq(project.description)
+      expect(json[0]['location']).to eq(project.location)
+      expect(json[0]['to_param']).to eq(project.to_param)
     end
 
     describe 'Volunteering' do
       let!(:no_volunteers_project) { FactoryBot.create(:project, user: user, accepting_volunteers: false) }
 
       it 'filters by ?accepting_volunteers=0' do
-        get :index, params: { accepting_volunteers: "0" }
+        get :index, params: { accepting_volunteers: '0' }
         expect(response).to be_successful
         expect(assigns(:projects)).to include(no_volunteers_project)
         expect(assigns(:projects)).to_not include(project)
-      end 
+      end
 
       it 'filters by ?accepting_volunteers=1' do
-        get :index, params: { accepting_volunteers: "1" }
+        get :index, params: { accepting_volunteers: '1' }
         expect(response).to be_successful
         expect(assigns(:projects)).to_not include(no_volunteers_project)
         expect(assigns(:projects)).to include(project)
-      end 
+      end
 
       it 'hides volunteer action item' do
         Project.update_all(accepting_volunteers: true)
         get :index
         expect(response.body.scan('sign up to volunteer').size).to be > 0
-      end 
+      end
 
       it 'shows volunteer action item' do
         Project.update_all(accepting_volunteers: false)
         get :index
         expect(response.body.scan('sign up to volunteer').size).to eq(0)
-      end 
-    end 
+      end
+    end
   end
 
   describe 'GET #show' do
@@ -68,51 +68,50 @@ RSpec.describe ProjectsController, type: :controller do
       get :show, params: { id: project.to_param }, format: 'json'
       json = JSON.parse(response.body)
       expect(response).to be_successful
-      expect(json["name"]).to eq(project.name)
-      expect(json["description"]).to eq(project.description)
-      expect(json["location"]).to eq(project.location)
-      expect(json["accepting_volunteers"]).to eq(project.accepting_volunteers)
-      expect(json["to_param"]).to eq(project.to_param)
+      expect(json['name']).to eq(project.name)
+      expect(json['description']).to eq(project.description)
+      expect(json['location']).to eq(project.location)
+      expect(json['accepting_volunteers']).to eq(project.accepting_volunteers)
+      expect(json['to_param']).to eq(project.to_param)
     end
 
     describe 'Volunteering' do
       it 'hide volunteer info' do
-        project.number_of_volunteers = "100";
+        project.number_of_volunteers = '100'
         project.accepting_volunteers = false
         project.save
         get :show, params: { id: project.to_param }
         expect(response).to be_successful
-        expect(response.body).to_not include("Number of volunteers")
+        expect(response.body).to_not include('Number of volunteers')
       end
 
       it 'show volunteer info' do
-        project.number_of_volunteers = "100";
+        project.number_of_volunteers = '100'
         project.accepting_volunteers = true
         project.save
         get :show, params: { id: project.to_param }
         expect(response).to be_successful
-        expect(response.body).to include("Number of volunteers")
+        expect(response.body).to include('Number of volunteers')
       end
 
       it 'shows volunteer button if your profile is complete' do
         user = FactoryBot.create(:user_complete_profile)
         sign_in user
-        user.skill_list.add("Design")
+        user.skill_list.add('Design')
         user.save
-        project.skill_list.add("Design")
+        project.skill_list.add('Design')
         project.save
         get :show, params: { id: project.to_param }
-        expect(response.body).to include("volunteers-btn")
+        expect(response.body).to include('volunteers-btn')
       end
 
       it 'shows volunteer filled button if you dont have the right skills' do
         user = FactoryBot.create(:user_complete_profile)
         sign_in user
         get :show, params: { id: project.to_param }
-        expect(response.body).to include("volunteers-filled-btn")
+        expect(response.body).to include('volunteers-filled-btn')
       end
     end
-
   end
 
   describe 'GET #new' do
@@ -145,7 +144,7 @@ RSpec.describe ProjectsController, type: :controller do
     it 'works' do
       sign_in user
       post :create, params: valid_params
-      expect(assigns(:project)).to be_present 
+      expect(assigns(:project)).to be_present
       expect(response).to be_redirect
     end
   end
@@ -166,7 +165,4 @@ RSpec.describe ProjectsController, type: :controller do
       fail
     end
   end
-
-
-
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -17,9 +17,15 @@ FactoryBot.define do
     password { "df823jls18fk350f" }
   end
 
+  factory :user_complete_profile, parent: :user do
+    about { "About" }
+    profile_links { "Profile" }
+    location { "location" }
+  end
+
 	factory :project do
-		name { "My First Project" }
-	end
+    name { "My First Project" }
+  end
 
 	factory :volunteer do
 		# ...

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Project, type: :model do
     expect(project).to be_valid
   end
 
+  it 'is invalid without a name' do
+    user = FactoryBot.create(:user)
+    project = FactoryBot.build(:project, name: nil)
+    expect(project).to_not be_valid
+  end
+
   it 'is invalid without a user' do
     project = FactoryBot.build(:project, user: nil)
     expect(project).to_not be_valid

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Project, type: :model do
   end
 
   it 'is invalid without a name' do
-    user = FactoryBot.create(:user)
     project = FactoryBot.build(:project, name: nil)
     expect(project).to_not be_valid
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,51 +4,50 @@ RSpec.describe User, type: :model do
   let(:user) { FactoryBot.build(:user) }
   let(:project) { FactoryBot.build(:project, user: user) }
 
-  it "factory is valid" do
+  it 'factory is valid' do
     user = FactoryBot.build(:user)
     expect(user).to be_valid
   end
 
-  it "is invalid without email" do
+  it 'is invalid without email' do
     user = FactoryBot.build(:user, email: nil)
     expect(user).to_not be_valid
   end
 
-  it "is invalid without password" do
+  it 'is invalid without password' do
     user = FactoryBot.build(:user, password: nil)
-    
     expect(user).to_not be_valid
   end
 
-  describe "Complete profile" do
-    it "is incomplete" do 
-      user = FactoryBot.build(:user, profile_links: "test", location: "test")
+  describe 'Complete profile' do
+    it 'is incomplete' do
+      user = FactoryBot.build(:user, profile_links: 'test', location: 'test')
       expect(user.has_complete_profile?).to eq(false)
     end
 
-    it "is complete" do 
-      user = FactoryBot.build(:user, about: "test", profile_links: "test", location: "test")
+    it 'is complete' do
+      user = FactoryBot.build(:user, about: 'test', profile_links: 'test', location: 'test')
       expect(user.has_complete_profile?).to eq(true)
     end
 
-    it "doesnt have right skills for project" do
-      user.skill_list.add(["Engineer"])
+    it 'doesnt have right skills for project' do
+      user.skill_list.add(['Engineer'])
       user.save!
-      project.skill_list.add(["Design"])
+      project.skill_list.add(['Design'])
       project.save!
       expect(user.has_correct_skills?(project)).to eq(false)
     end
 
-    it "has right skills for project" do
-      user.skill_list.add(["Design", "Engineer"])
+    it 'has right skills for project' do
+      user.skill_list.add(['Design', 'Engineer'])
       user.save!
-      project.skill_list.add(["Design"])
+      project.skill_list.add(['Design'])
       project.save!
       expect(user.has_correct_skills?(project)).to eq(true)
     end
 
-    it "has right skills if project requires `Anything`" do
-      project.skill_list.add(["Anything"])
+    it 'has right skills if project requires `Anything`' do
+      project.skill_list.add(['Anything'])
       project.save!
       expect(user.has_correct_skills?(project)).to eq(true)
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  let(:user) { FactoryBot.build(:user) }
+  let(:project) { FactoryBot.build(:project, user: user) }
+
   it "factory is valid" do
     user = FactoryBot.build(:user)
     expect(user).to be_valid
@@ -13,7 +16,41 @@ RSpec.describe User, type: :model do
 
   it "is invalid without password" do
     user = FactoryBot.build(:user, password: nil)
+    
     expect(user).to_not be_valid
   end
 
+  describe "Complete profile" do
+    it "is incomplete" do 
+      user = FactoryBot.build(:user, profile_links: "test", location: "test")
+      expect(user.has_complete_profile?).to eq(false)
+    end
+
+    it "is complete" do 
+      user = FactoryBot.build(:user, about: "test", profile_links: "test", location: "test")
+      expect(user.has_complete_profile?).to eq(true)
+    end
+
+    it "doesnt have right skills for project" do
+      user.skill_list.add(["Engineer"])
+      user.save!
+      project.skill_list.add(["Design"])
+      project.save!
+      expect(user.has_correct_skills?(project)).to eq(false)
+    end
+
+    it "has right skills for project" do
+      user.skill_list.add(["Design", "Engineer"])
+      user.save!
+      project.skill_list.add(["Design"])
+      project.save!
+      expect(user.has_correct_skills?(project)).to eq(true)
+    end
+
+    it "has right skills if project requires `Anything`" do
+      project.skill_list.add(["Anything"])
+      project.save!
+      expect(user.has_correct_skills?(project)).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
- Switched to radio buttons per @sradu's suggestion. Much nicer.
- Minor copy changes
- Started to fill out `seeds.rb` so that `rails db:setup` prepopulates with some data.
- Added basic tests for project name validation and creation


![image](https://user-images.githubusercontent.com/156097/78273708-38565d80-74dd-11ea-9a5c-055cd58acf95.png)

- If `accepting_volunteers?==true` then in order to volunteer for a project, a user must have a skill that matches the list of skills required for a project. If you don't match, you will see this button:
![image](https://user-images.githubusercontent.com/156097/78307456-f09ef880-7513-11ea-9b81-f2e7bb152306.png)
and if you click the button, it will say 
![image](https://user-images.githubusercontent.com/156097/78307474-fb598d80-7513-11ea-802a-fa8609180254.png)
