### PR TITLE
Basic Google Analytics event tracking

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::Base
     @show_global_announcements = true
   end
 
-  def track_event(action)
-    session[:track_event] = action
+  def track_event(event_name)
+    session[:track_event] = event_name
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,9 +31,4 @@ class ApplicationController < ActionController::Base
   def track_event(action)
     session[:track_event] = action
   end
-
-  def pop_event_to_track
-    session.delete(:track_event)
-  end
-  helper_method :pop_event_to_track
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,4 +27,13 @@ class ApplicationController < ActionController::Base
   def show_global_announcements
     @show_global_announcements = true
   end
+
+  def track_event(action)
+    session[:track_event] = action
+  end
+
+  def pop_event_to_track
+    session.delete(:track_event)
+  end
+  helper_method :pop_event_to_track
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -71,17 +71,15 @@ class ProjectsController < ApplicationController
 
   def new
     @project = Project.new
-
     track_event 'Project creation started'
   end
 
   def create
     @project = current_user.projects.new(project_params)
 
-    track_event 'Project creation complete'
-
     respond_to do |format|
       if @project.save
+        track_event 'Project creation complete'
         format.html { redirect_to @project, notice: 'Project was successfully created.' }
         format.json { render :show, status: :created, location: @project }
       else

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -71,12 +71,14 @@ class ProjectsController < ApplicationController
 
   def new
     @project = Project.new
+
+    track_event 'Project creation started'
   end
 
   def create
-    @project = Project.new(project_params)
+    @project = current_user.projects.new(project_params)
 
-    @project.user = current_user
+    track_event 'Project creation complete'
 
     respond_to do |format|
       if @project.save
@@ -122,6 +124,7 @@ class ProjectsController < ApplicationController
       ProjectMailer.with(project: @project, user: current_user, note: params[:volunteer_note]).new_volunteer.deliver_now
 
       flash[:notice] = 'Thanks for volunteering! The project owners will be alerted.'
+      track_event "User volunteered"
     end
 
     redirect_to project_path(@project)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -122,7 +122,7 @@ class ProjectsController < ApplicationController
       ProjectMailer.with(project: @project, user: current_user, note: params[:volunteer_note]).new_volunteer.deliver_now
 
       flash[:notice] = 'Thanks for volunteering! The project owners will be alerted.'
-      track_event "User volunteered"
+      track_event 'User volunteered'
     end
 
     redirect_to project_path(@project)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -49,15 +49,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
     end
   end
 
-  # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+  def new
+    track_event 'User registration started'
+    super
+  end
 
-  # POST /resource
-  # def create
-  #   super
-  # end
+  def create
+    track_event 'User registration complete'
+    super
+  end
 
   # GET /resource/edit
   # def edit

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -170,4 +170,9 @@ module ApplicationHelper
   def google_analytics_id
     Rails.env.production? ? 'UA-162054776-1' : 'UA-162054776-2'
   end
+
+  def pop_event_to_track
+    session.delete(:track_event)
+  end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -166,4 +166,8 @@ module ApplicationHelper
 
     "<option value='#{path}' #{'selected' if active}>#{title}</option>".html_safe
   end
+
+  def google_analytics_id
+    Rails.env.production? ? 'UA-162054776-1' : 'UA-162054776-2'
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -175,7 +175,7 @@ module ApplicationHelper
     event = session.delete(:track_event)
     return '' if event.blank?
 
-    "gtag('event', '#{event}', {'event_category': 'Actions'});"
+    "gtag('event', '#{event}', {'event_category': 'Actions'});".html_safe
   end
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -171,8 +171,11 @@ module ApplicationHelper
     Rails.env.production? ? 'UA-162054776-1' : 'UA-162054776-2'
   end
 
-  def pop_event_to_track
-    session.delete(:track_event)
+  def track_ga_event_if_needed
+    event = session.delete(:track_event)
+    return '' if event.blank?
+
+    "gtag('event', '#{event}', {'event_category': 'Actions'});"
   end
 
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,17 +14,25 @@
     <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.0.1/dist/alpine.js" defer></script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
 
-    <% if Rails.env == 'production' %>
-      <!-- Global site tag (gtag.js) - Google Analytics -->
-      <script async src="https://www.googletagmanager.com/gtag/js?id=UA-162054776-1"></script>
+      <%# Always load GA, for consistency, but use different accounts for development vs. production %>
+      <script async src="https://www.googletagmanager.com/gtag/js?id=<%= google_analytics_id %>"></script>
       <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
 
-        gtag('config', 'UA-162054776-1');
+        gtag('config', '<%= google_analytics_id %>');
+
+        <% action = pop_event_to_track %>
+        <% if action.present? %>
+          // console.log("Logging event...", "<%= action %>");
+          gtag('event', "<%= action %>", {
+            'event_category': "Actions"
+            // 'event_label': '',
+            // 'value': ''
+          });
+        <% end %>
       </script>
-    <% end %>
   </head>
 
   <body class="flex flex-col min-h-screen h-full antialiased <%= 'bg-gray-100' if request.original_fullpath != root_path %>">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,10 +23,9 @@
 
         gtag('config', '<%= google_analytics_id %>');
 
-        <% action = pop_event_to_track %>
-        <% if action.present? %>
-          // console.log("Logging event...", "<%= action %>");
-          gtag('event', "<%= action %>", {
+        <% if (event_name = pop_event_to_track).present? %>
+          // console.log("Logging event...", "<%= event_name %>");
+          gtag('event', "<%= event_name %>", {
             'event_category': "Actions"
             // 'event_label': '',
             // 'value': ''

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,23 +14,13 @@
     <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.0.1/dist/alpine.js" defer></script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
 
-      <%# Always load GA, for consistency, but use different accounts for development vs. production %>
       <script async src="https://www.googletagmanager.com/gtag/js?id=<%= google_analytics_id %>"></script>
       <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-
         gtag('config', '<%= google_analytics_id %>');
-
-        <% if (event_name = pop_event_to_track).present? %>
-          // console.log("Logging event...", "<%= event_name %>");
-          gtag('event', "<%= event_name %>", {
-            'event_category': "Actions"
-            // 'event_label': '',
-            // 'value': ''
-          });
-        <% end %>
+        <%= track_ga_event_if_needed %>
       </script>
   </head>
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -41,7 +41,8 @@ user6 = User.create!(email: 'user6@gmail.com', name: 'jamiew', password: 'passwo
 project1 = user.projects.create(
   status: ALL_PROJECT_STATUS.shuffle.first, 
   name: 'Act Now Foundation - Import & distribution of 10-minute at home COVID-19 test kits', 
-  location: 'USA', 
+  target_location: 'USA', 
+  volunteer_location: 'Anywhere',
   description: 'A cool description', 
   accepting_volunteers: true, 
   highlight: true)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -38,9 +38,16 @@ user5 = User.create!(email: 'user5@gmail.com', name: 'cpu', password: 'password'
 user6 = User.create!(email: 'user6@gmail.com', name: 'jamiew', password: 'password', password_confirmation: 'password')
 
 # PROJECTS
-project1 = user.projects.create(user: user, status: ALL_PROJECT_STATUS.shuffle.first, name: 'Act Now Foundation - Import & distribution of 10-minute at home COVID-19 test kits', target_location: 'USA', description: 'A cool description', accepting_volunteers: true, highlight: true)
+project1 = user.projects.create(
+  status: ALL_PROJECT_STATUS.shuffle.first, 
+  name: 'Act Now Foundation - Import & distribution of 10-minute at home COVID-19 test kits', 
+  location: 'USA', 
+  description: 'A cool description', 
+  accepting_volunteers: true, 
+  highlight: true)
 project1.skill_list.add('Anything')
-project1.save! # FIXME is this necessary?
+project1.volunteered_users << user3
+project1.save! # FIXME is this necessary? We were modifying associations
 
 project2 = Project.create!(
   user: user2,

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -141,10 +141,10 @@ RSpec.describe ProjectsController, type: :controller do
       expect(response).to_not be_successful
     end
 
-    it 'sets @track_event' do
+    it 'tracks an event' do
       sign_in user
       get :new
-      expect(assigns(:track_event)).to eq('Project creation started')
+      expect(session[:track_event]).to eq('Project creation started')
     end
 
   end
@@ -170,10 +170,10 @@ RSpec.describe ProjectsController, type: :controller do
       expect(response).to be_redirect
     end
 
-    it 'sets @track_event' do
+    it 'tracks an event' do
       sign_in(user)
       post :create, params: valid_params
-      expect(assigns(:track_event)).to eq('Project creation complete')
+      expect(session[:track_event]).to eq('Project creation complete')
     end
   end
 
@@ -200,7 +200,7 @@ RSpec.describe ProjectsController, type: :controller do
       fail
     end
 
-    it 'sets @track_event if you are not currently a volunteer' do
+    it 'tracks an event if you are not currently a volunteer' do
       pending 'TODO'
       fail
     end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -143,8 +143,11 @@ RSpec.describe ProjectsController, type: :controller do
 
     it 'tracks an event' do
       sign_in user
+      expect(controller).to receive(:track_event).with('Project creation started').and_call_original
       get :new
-      expect(session[:track_event]).to eq('Project creation started')
+      # This doesn't work since the GET request sets and deletes the variable within same request
+      # expect(session[:track_event]).to eq('Project creation started')
+      expect(response.body).to match(/Project creation started/)
     end
 
   end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -140,6 +140,13 @@ RSpec.describe ProjectsController, type: :controller do
       get :new
       expect(response).to_not be_successful
     end
+
+    it 'sets @track_event' do
+      sign_in user
+      get :new
+      expect(assigns(:track_event)).to eq('Project creation started')
+    end
+
   end
 
   describe 'GET #edit' do
@@ -162,6 +169,12 @@ RSpec.describe ProjectsController, type: :controller do
       expect(assigns(:project)).to be_present
       expect(response).to be_redirect
     end
+
+    it 'sets @track_event' do
+      sign_in(user)
+      post :create, params: valid_params
+      expect(assigns(:track_event)).to eq('Project creation complete')
+    end
   end
 
   describe 'PUT #update' do
@@ -180,4 +193,23 @@ RSpec.describe ProjectsController, type: :controller do
       fail
     end
   end
+
+  describe 'POST #toggle_volunteer' do
+    it 'volunteers you if you are not currently a volunteer' do
+      pending 'TODO'
+      fail
+    end
+
+    it 'sets @track_event if you are not currently a volunteer' do
+      pending 'TODO'
+      fail
+    end
+
+    it 'unvolunteers you if you had already volunteered' do
+      pending 'TODO'
+      fail
+    end
+
+  end
+
 end

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe Users::RegistrationsController do
   end
 
   describe 'GET #new' do
-    it 'sets @track_event' do
+    it 'tracks an event' do
       pending 'TODO'
       fail
     end
   end
 
   describe 'POST #create' do
-    it 'sets @track_event' do
+    it 'tracks an event' do
       pending 'TODO'
       fail
     end

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Users::RegistrationsController do
+  describe 'GET #index' do
+    it 'works' do
+      pending 'TODO'
+      fail
+    end
+  end
+
+  describe 'GET #show' do
+    it 'works' do
+      pending 'TODO'
+      fail
+    end
+  end
+
+  describe 'GET #new' do
+    it 'sets @track_event' do
+      pending 'TODO'
+      fail
+    end
+  end
+
+  describe 'POST #create' do
+    it 'sets @track_event' do
+      pending 'TODO'
+      fail
+    end
+  end
+
+
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -45,4 +45,30 @@ RSpec.describe ApplicationHelper do
     desired_qs = 'skills=Biology&project_types=Track+the+outbreak,Reduce+spread&filters_open=true'
     assert querystring.eql? desired_qs
   end
+
+  describe '#pop_event_to_track' do
+    it 'works' do
+      # Ideally would do `track_event` -> `pop_event_to_track` but this is fine
+      session[:track_event] = 'Really cool event'
+      expect(pop_event_to_track).to eq('Really cool event')
+    end
+  end
+
+  describe '#google_analytics_id' do
+    it 'returns the dev account id for development mode (ends in -2)' do
+      allow(Rails).to receive(:env) { 'development'.inquiry }
+      expect(google_analytics_id).to eq('UA-162054776-2')
+    end
+
+    it 'returns the dev account id for test mode (ends in -2)' do
+      allow(Rails).to receive(:env) { 'test'.inquiry }
+      expect(google_analytics_id).to eq('UA-162054776-2')
+    end
+
+    it 'returns the real account id for production mode (ends in -1)' do
+      allow(Rails).to receive(:env) { 'production'.inquiry }
+      expect(google_analytics_id).to eq('UA-162054776-1')
+    end
+  end
+
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -46,11 +46,10 @@ RSpec.describe ApplicationHelper do
     assert querystring.eql? desired_qs
   end
 
-  describe '#pop_event_to_track' do
+  describe '#track_ga_event_if_needed' do
     it 'works' do
-      # Ideally would do `track_event` -> `pop_event_to_track` but this is fine
       session[:track_event] = 'Really cool event'
-      expect(pop_event_to_track).to eq('Really cool event')
+      expect(track_ga_event_if_needed).to match(/Really cool event/)
     end
   end
 


### PR DESCRIPTION
* Log events for user creation, project creation and volunteering
* Track 'start' and 'complete' events separately so we can look at the funnel
* Uses Rails session to push and pop the action name
* Uses one 'Actions' GA category for simplicity
* Always load GA javascript code, no matter the environment, but use a new GA property that I setup just for dev/test. This is so we don't accidentally break production. 

Would love some eyes on this, particularly if anyone cares about my overly verbose event names. I don't totally love the session-based approach but it is reliable.

fixes #117 