### PR TITLE
Rename the "Upcoming HWC Events" block on homepage

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -43,7 +43,7 @@
 <div class="bg-indigo-600">
   <div class="container pt-10 pb-8 px-4">
     <% if Settings.events.present? %>
-      <div class="text-white mb-4"><%= section_name 'Upcoming HWC events' %></div>
+      <div class="text-white mb-4"><%= section_name 'Resources & Events' %></div>
       <div class="sm:grid grid-cols-3 gap-6">
         <%= render partial: 'event-card', collection: Settings.events, as: :event, cached: true %>
       </div>


### PR DESCRIPTION
Some are resources, some are past events, some are
future events. It's a variety really