### PR TITLE
fix: project-group-query-any-project

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -150,8 +150,8 @@ class ProjectsController < ApplicationController
       applied_project_types = (params[:project_types] or '').split(',')
 
       @projects = Project
-      @projects = @projects.tagged_with(applied_skills) if applied_skills.length > 0
-      @projects = @projects.tagged_with(applied_project_types) if applied_project_types.length > 0
+      @projects = @projects.tagged_with(applied_skills, any: params[:any]) if applied_skills.length > 0
+      @projects = @projects.tagged_with(applied_project_types, any: params[:any]) if applied_project_types.length > 0
       @projects = @projects.where(accepting_volunteers: params[:accepting_volunteers] == "1") if params[:accepting_volunteers].present?
 
       if params[:query].present?

--- a/app/views/home/_project-group.html.erb
+++ b/app/views/home/_project-group.html.erb
@@ -7,7 +7,7 @@
         <div class="flex-1">
           <%= group[:body] %>
         </div>
-        <%= link_to projects_path(project_types: group[:project_types].join(',')), class: 'float-right text-indigo-700 font-bold group' do %>
+        <%= link_to projects_path(project_types: group[:project_types].join(','), any: true), class: 'float-right text-indigo-700 font-bold group' do %>
           See all <%= group[:projects_count] %> <%= 'project'.pluralize group[:projects_count] %> <%= inline_svg_pack_tag 'media/svgs/chevron-right.svg', class: 'inline-block fill-current transform transition-transform duration-100 -translate-x-1 group-hover:translate-x-0' %>
         <% end %>
       </div>


### PR DESCRIPTION
The "See all X projects" is sending the user on a filter that has actually less than X projects. The link query count is made by using the `any: true` param and the actual page query is not using it.

Fixed that by adding a hidden `any=true` filter.