### PR TITLE
Add rubocop step to circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,4 +80,9 @@ jobs: # a collection of steps
       # Save test results for timing analysis
       - store_test_results: # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
           path: test_results
+
+      - run:
+          name: Rubocop
+          command: bundle exec rubocop
+
       # See https://circleci.com/docs/2.0/deployment-integrations/ for example deploy configs

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Help is welcome! We are communicating on [Discord](https://discord.gg/8nAJfFN) i
 
 1. Fork the project
 1. Create a branch with your changes
+1. Make sure all test are passing by running `bundle exec rails spec`
+1. Make sure rubocop is happy by running `bundle exec rubocop` (you can run `bundle exec rubocop -a` to automatically fix errors)
 1. Submit a pull request
 
 # License


### PR DESCRIPTION
This PR addresses [issue 144](https://github.com/helpwithcovid/covid-volunteers/issues/143) by adding rubocop to the circleci build steps.

I have checked that my changes to `config.yml` are valid using the circleci CLI tool.