### PR TITLE
Refines project card styles

### DIFF
--- a/app/frontend/styles/application.css
+++ b/app/frontend/styles/application.css
@@ -28,3 +28,13 @@
   -ms-overflow-style: none; /* IE 11 */
   scrollbar-width: none; /* Firefox 64 */
 }
+
+/* Scroll Affordance Gradient on Project Card Labels */
+.scroll-gradient-right:after {
+  content: "";
+  width: 1rem;
+  height: 24px;
+  position: fixed;
+  right: 1.25rem; /* set to value of Tailwind padding class,`px-5` */
+  background: linear-gradient(to left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 100%);
+}

--- a/app/views/projects/_project-card.html.erb
+++ b/app/views/projects/_project-card.html.erb
@@ -2,16 +2,16 @@
   <div class="w-full bg-center bg-cover" style="height: 130px; background-image: url(<%= project.cover_photo(local_assigns[:group]) %>);"></div>
 
   <% if project.accepting_volunteers? %>
-    <div class="absolute inset-auto right-0 top-0 mr-4 mt-4 z-10 text-white rounded-full px-2 py-1 text-sm" style="background-color: rgba(0, 0, 0, 0.5);"><%= inline_svg_pack_tag 'media/svgs/status-bolt.svg', class: 'inline' %>Actively Recruiting</div>
+    <div class="absolute inset-auto right-0 top-0 mr-4 mt-4 z-10 text-white rounded-full px-3 py-1 text-xs" style="background-color: rgba(0, 0, 0, 0.5);"><span class="pr-1"><%= inline_svg_pack_tag 'media/svgs/status-bolt.svg', class: 'inline' %></span> Actively Recruiting</div>
   <% end %>
 
-  <div class="p-4">
-    <div class="text-2xl truncate leading-tight mb-1"><%= project.name %></div>
-    <div class="text-gray-500 text-sm mb-2 leading-tight overflow-hidden" style="height: 50px;"><%= project.description.truncate 150 %></div>
+  <div class="px-5 pt-5 pb-6">
+    <div class="text-lg font-medium truncate leading-tight mb-1"><%= project.name %></div>
+    <div class="text-gray-500 text-sm mb-5 leading-tight overflow-hidden" style="height: 50px;"><%= project.description.truncate 150 %></div>
 
     <% if project.project_types.present? %>
-      <div class="relative w-full overflow-x-auto scrolling-touch scrollbar-hidden h-6 mb-2">
-        <div class="flex flex-row flex-no-wrap flex-shrink-0 h-full flex-shrink-0 space-x-right-2">
+      <div class="relative w-full overflow-x-auto scrolling-touch scrollbar-hidden h-6 mb-4">
+        <div class="scroll-gradient-right flex flex-row flex-no-wrap flex-shrink-0 h-full flex-shrink-0 space-x-right-2">
           <% project.project_types.each do |type| %>
             <%= filter_badge label: type %>
           <% end %>
@@ -19,7 +19,8 @@
       </div>
     <% end %>
 
-    <div class="relative grid grid-cols-3 gap-2 text-sm mt-3">
+    <div class="relative grid grid-cols-2 gap-2 text-xs mt-3">
+
       <% total_volunteers = project.volunteers.count %>
       <div class="font-bold">
         <% if total_volunteers > 0 %>
@@ -29,10 +30,13 @@
         <% end %>
       </div>
 
-      <div class="text-gray-500 w-full text-center"><%= time_ago_in_words project.created_at %> ago</div>
       <% if project.volunteer_location? %>
         <div class="text-right"><%= inline_svg_pack_tag 'media/svgs/project-card-location.svg', class: 'inline' %><%= project.volunteer_location %></div>
       <% end %>
+
     </div>
+
+    <div class="text-xs text-gray-500 text-left w-full"><%= time_ago_in_words project.created_at %> ago</div>
+
   </div>
 <% end %>


### PR DESCRIPTION
Fixes #145 

Refined the spacing and sizing overall in the project card component.

I added a scroll affordance gradient on the card label component (it appears slightly over labels that do not scroll if last label's edge is right at the edge of the container—would require some JS to show gradient only if elements extended past right edge).

I rearranged the elements on the bottom of the cards to accommodate situations where the location or the updated info was wrapping.

**Project Cards on Homepage - Before and After**

![Project Cards on Homepage - Before](https://user-images.githubusercontent.com/1129103/79156607-10da7d00-7d88-11ea-8df3-f5a2a5122c6d.png)

![Project Cards on Homepage - After](https://user-images.githubusercontent.com/1129103/79156601-0fa95000-7d88-11ea-8a76-571b6999d068.png)

**Project Card - Before and After** 

![Project Card - Before](https://user-images.githubusercontent.com/1129103/79156597-0f10b980-7d88-11ea-83e4-98b19bb7acd3.png)

![Project Card - After](https://user-images.githubusercontent.com/1129103/79156591-0d46f600-7d88-11ea-9674-1b7780d3b557.png)

