### PR TITLE
Temporary hotfix for broken "Create project" flow

### DIFF
--- a/app/views/projects/_project_form.html.erb
+++ b/app/views/projects/_project_form.html.erb
@@ -207,7 +207,7 @@
     </label>
     <div class="mt-1 sm:mt-0 sm:col-span-2">
       <div class="max-w-lg flex rounded-md shadow-sm">
-        <%= f.text_field "volunteer_location", class: "flex-1 form-input block w-full rounded-none rounded-r-md transition duration-150 ease-in-out sm:text-sm sm:leading-5", required: true %>
+        <%= f.text_field "volunteer_location", class: "flex-1 form-input block w-full rounded-none rounded-r-md transition duration-150 ease-in-out sm:text-sm sm:leading-5", required: false %>
       </div>
       <p class="mt-2 text-sm text-gray-500">Do volunteers need to live in a certain location? Write remote otherwise.</p>
     </div>


### PR DESCRIPTION
If you select "No, I don't need any volunteers," this
volunteer_location field is not visible and the javascript
error-checking blocks submitting the form.

If you switch to "yes" and put in a value in, then switch
back to "no" it works again.