### PR TITLE
Fix: Add rel="nofollow noopener noreferrer" to outbound links

### DIFF
--- a/app/views/devise/registrations/show.html.erb
+++ b/app/views/devise/registrations/show.html.erb
@@ -67,7 +67,7 @@
             Interesting links
           </dt>
           <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
-            <%= simple_format Rinku.auto_link(sanitize(@user.profile_links), :all, 'class="text-indigo-500"'), class: 'mb-3' %>
+            <%= simple_format Rinku.auto_link(sanitize(@user.profile_links), :all, 'class="text-indigo-500" rel="nofollow noopener noreferrer"'), { class: 'mb-3' }, sanitize: false %>
           </dd>
         </div>
         <div class="mt-8 sm:mt-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:border-t sm:border-gray-200 sm:px-6 sm:py-5">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -268,7 +268,7 @@
               Short description
             </dt>
             <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
-              <%= simple_format @project.short_description, class: 'mb-3' %>
+              <%= simple_format Rinku.auto_link(sanitize(@project.short_description), :all, 'class="text-indigo-500" rel="nofollow noopener noreferrer"'), { class: 'mb-3' }, sanitize: false %>
             </dd>
           </div>
         <% end %>
@@ -277,7 +277,7 @@
             Description
           </dt>
           <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
-            <%= simple_format @project.description, class: 'mb-3' %>
+            <%= simple_format Rinku.auto_link(sanitize(@project.description), :all, 'class="text-indigo-500" rel="nofollow noopener noreferrer"'), { class: 'mb-3' }, sanitize: false %>
           </dd>
         </div>
         <div class="mt-8 sm:mt-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:border-t sm:border-gray-200 sm:px-6 sm:pt-5 sm:pb-2">
@@ -285,7 +285,7 @@
             Who is already working on this
           </dt>
           <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
-            <%= simple_format Rinku.auto_link(sanitize(@project.participants), :all, 'class="text-indigo-500"'), class: 'mb-3' %>
+            <%= simple_format Rinku.auto_link(sanitize(@project.participants), :all, 'class="text-indigo-500" rel="nofollow noopener noreferrer"'), { class: 'mb-3' }, sanitize: false %>
           </dd>
         </div>
         <% if @project.progress.present? %>
@@ -294,7 +294,7 @@
               How far along it is
             </dt>
             <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
-              <%= simple_format Rinku.auto_link(sanitize(@project.progress), :all, 'class="text-indigo-500"'), class: 'mb-3' %>
+              <%= simple_format Rinku.auto_link(sanitize(@project.progress), :all, 'class="text-indigo-500" rel="nofollow noopener noreferrer"'), { class: 'mb-3' }, sanitize: false %>
             </dd>
           </div>
         <% end %>
@@ -304,7 +304,7 @@
               Demo, mockups, or documentation
             </dt>
             <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
-              <%= simple_format Rinku.auto_link(sanitize(@project.docs_and_demo), :all, 'class="text-indigo-500"'), class: 'mb-3' %>
+              <%= simple_format Rinku.auto_link(sanitize(@project.docs_and_demo), :all, 'class="text-indigo-500" rel="nofollow noopener noreferrer"'), { class: 'mb-3' }, sanitize: false %>
             </dd>
           </div>
         <% end %>
@@ -315,7 +315,7 @@
               How to get in touch
             </dt>
             <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2 sm:pb-3">
-              <%= Rinku.auto_link(sanitize(@project.contact), :all, 'class="text-indigo-500"').html_safe %>
+              <%= Rinku.auto_link(sanitize(@project.contact), :all, 'class="text-indigo-500" rel="nofollow noopener noreferrer"').html_safe %>
             </dd>
           </div>
         <% end %>
@@ -346,7 +346,7 @@
               Helpful links
             </dt>
             <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2 flex content-center flex-wrap space-y-bottom-2 -mb-2 space-x-right-2">
-              <%= simple_format Rinku.auto_link(sanitize(@project.links), :all, 'class="text-indigo-500"'), class: 'mb-3' %>
+              <%= simple_format Rinku.auto_link(sanitize(@project.links), :all, 'class="text-indigo-500" rel="nofollow noopener noreferrer"'), { class: 'mb-3' }, sanitize: false %>
             </dd>
           </div>
         <% end %>


### PR DESCRIPTION
Closes #162

Also. added link support to `@project.short_description` and `@project.description` blocks, but could remove those if those were excluded on purpose.