### PR TITLE
Lint all of the things

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,4 +80,9 @@ jobs: # a collection of steps
       # Save test results for timing analysis
       - store_test_results: # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
           path: test_results
+
+      - run:
+          name: Rubocop
+          command: bundle exec rubocop
+
       # See https://circleci.com/docs/2.0/deployment-integrations/ for example deploy configs

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,14 +8,17 @@ AllCops:
   # to ignore them, so only the ones explicitly set in this file are enabled.
   DisabledByDefault: true
   Exclude:
+    - '**/node_modules/**/*'
     - '**/tmp/**/*'
     - '**/templates/**/*'
     - '**/vendor/**/*'
     - 'actionpack/lib/action_dispatch/journey/parser.rb'
-    - 'railties/test/fixtures/tmp/**/*'
     - 'actionmailbox/test/dummy/**/*'
     - 'actiontext/test/dummy/**/*'
-    - '**/node_modules/**/*'
+    - 'bin/*'
+    - 'db/schema.rb'
+    - 'db/migrate/*'
+    - 'railties/test/fixtures/tmp/**/*'
 
 Performance:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -133,7 +133,7 @@ Style/MethodDefParentheses:
   Enabled: true
 
 Style/FrozenStringLiteralComment:
-  Enabled: true
+  Enabled: false
   EnforcedStyle: always
   Exclude:
     - 'actionview/test/**/*.builder'

--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ gem 'aws-sdk-rails'
 # Exceptions.
 gem 'exception_notification', git: 'https://github.com/smartinez87/exception_notification'
 
-#Search
+# Search
 gem 'pg_search'
 
 # Email obfuscation

--- a/app/controllers/admin/volunteer_groups_controller.rb
+++ b/app/controllers/admin/volunteer_groups_controller.rb
@@ -47,8 +47,7 @@ class Admin::VolunteerGroupsController < ApplicationController
   end
 
   protected
-
-  def set_project
-    @project = Project.find(params[:project_id])
-  end
+    def set_project
+      @project = Project.find(params[:project_id])
+    end
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -18,5 +18,4 @@ class AdminController < ApplicationController
     redirect_to project_path(@project)
   end
 
-  private
-nd
+end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -17,5 +17,4 @@ class AdminController < ApplicationController
     flash[:notice] = @project.highlight? ? 'Project highlighted' : 'Removed highlight on project'
     redirect_to project_path(@project)
   end
-
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -5,7 +5,7 @@ class AdminController < ApplicationController
     @user = User.find(params[:user_id])
     @user.destroy!
 
-    flash[:notice] = "User deleted"
+    flash[:notice] = 'User deleted'
     redirect_to volunteers_path
   end
 
@@ -14,9 +14,9 @@ class AdminController < ApplicationController
     @project.highlight = !@project.highlight
     @project.save
 
-    flash[:notice] = @project.highlight? ? "Project highlighted" : "Removed highlight on project"
+    flash[:notice] = @project.highlight? ? 'Project highlighted' : 'Removed highlight on project'
     redirect_to project_path(@project)
   end
 
   private
-end
+nd

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
                       false
                     else
                       true
-                    end
+    end
   end
 
   def hide_global_announcements

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -136,7 +136,7 @@ class ProjectsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def project_params
-      params.fetch(:project, {}).permit(:name, :description, :participants, :looking_for, :contact, :volunteer_location, :target_country, :target_location, :progress, :docs_and_demo, :accepting_volunteers, :number_of_volunteers, :links, :status, :short_description, :skill_list => [], :project_type_list => [])
+      params.fetch(:project, {}).permit(:name, :description, :participants, :looking_for, :contact, :volunteer_location, :target_country, :target_location, :progress, :docs_and_demo, :accepting_volunteers, :number_of_volunteers, :links, :status, :short_description, skill_list: [], project_type_list: [])
     end
 
     def ensure_owner_or_admin

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -45,7 +45,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     if !@user.is_visible_to_user?(current_user)
       flash[:error] = 'Sorry, no such user.'
       redirect_to projects_path
-      return
+      nil
     end
   end
 
@@ -84,40 +84,39 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   protected
+    # If you have extra params to permit, append them to the sanitizer.
+    # def configure_sign_up_params
+    #   devise_parameter_sanitizer.permit(:sign_up, keys: [ :about, :profile_links, :location ])
+    # end
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [ :about, :profile_links, :location ])
-  # end
-
-  # If you have extra params to permit, append them to the sanitizer.
-  def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [ :name, :about, :profile_links, :location, :visibility, :pair_with_projects,  :level_of_availability, :skill_list => []])
-  end
-
-  # The path used after sign up.
-  def after_sign_up_path_for(resource)
-    projects_path
-  end
-
-  # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
-
-  def update_resource(resource, params)
-    if params[:password].present?
-      super(resource, params)
-    else
-      Rails.logger.error 'here pac pac'
-      params.delete(:password_confirmation)
-      params.delete(:current_password)
-      resource.update_without_password(params)
+    # If you have extra params to permit, append them to the sanitizer.
+    def configure_account_update_params
+      devise_parameter_sanitizer.permit(:account_update, keys: [ :name, :about, :profile_links, :location, :visibility, :pair_with_projects,  :level_of_availability, skill_list: []])
     end
-  end
 
-  def get_order_param
-    return 'created_at desc' if params[:sort_by] == 'latest'
-    return 'created_at asc' if params[:sort_by] == 'earliest'
-  end
+    # The path used after sign up.
+    def after_sign_up_path_for(resource)
+      projects_path
+    end
+
+    # The path used after sign up for inactive accounts.
+    # def after_inactive_sign_up_path_for(resource)
+    #   super(resource)
+    # end
+
+    def update_resource(resource, params)
+      if params[:password].present?
+        super(resource, params)
+      else
+        Rails.logger.error 'here pac pac'
+        params.delete(:password_confirmation)
+        params.delete(:current_password)
+        resource.update_without_password(params)
+      end
+    end
+
+    def get_order_param
+      return 'created_at desc' if params[:sort_by] == 'latest'
+      return 'created_at asc' if params[:sort_by] == 'earliest'
+    end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,7 +61,7 @@ module ApplicationHelper
     nav_link_inactive_class(variant)
   end
 
-  def alert_container_class_for_flash_type type
+  def alert_container_class_for_flash_type(type)
     base_class = 'border px-4 py-3 rounded relative'
 
     if [ 'alert', 'error'].include?(type)
@@ -92,18 +92,18 @@ module ApplicationHelper
       classes += ' bg-indigo-300' if applied
     end
 
-    render partial: 'partials/filter-badge', locals: {label: label, url: url, classes: classes, title: title}
+    render partial: 'partials/filter-badge', locals: { label: label, url: url, classes: classes, title: title }
   end
 
   def clear_filter_badge(label: nil, model: nil, filter_by: nil, color: nil, title: nil)
-    query_string = build_query_string(get_query_params.filter{|k, _| k!= filter_by})
+    query_string = build_query_string(get_query_params.filter { |k, _| k!= filter_by })
     url = "/#{model}"
     url << "?#{query_string}" if query_string.present?
 
     classes = 'bg-gray-100 text-gray-800'
     classes += ' bg-gray-200' if get_query_params[filter_by].length == 0
 
-    render partial: 'partials/filter-badge', locals: {label: label, url: url, classes: classes, title: title}
+    render partial: 'partials/filter-badge', locals: { label: label, url: url, classes: classes, title: title }
   end
 
   def get_query_params
@@ -121,7 +121,7 @@ module ApplicationHelper
   def toggle_filter(filter_key, filter)
     query_params = get_query_params
     filters = get_query_params[filter_key]
-    toggled = filters.include?(filter) ? filters.filter{|el| el != filter} : filters + [filter]
+    toggled = filters.include?(filter) ? filters.filter { |el| el != filter } : filters + [filter]
     query_params[filter_key] = toggled
     query_params
   end
@@ -129,7 +129,7 @@ module ApplicationHelper
   def build_query_string(query_params)
     params_array = query_params.map do |k, v|
       next if v.length == 0
-      value = v.map{|s| CGI.escape s}.join(',')
+      value = v.map { |s| CGI.escape s }.join(',')
       "#{k}=#{value}"
     end
     params_array.reject(&:nil?).join('&')
@@ -138,7 +138,7 @@ module ApplicationHelper
   def skill_badges(items, limit: nil, color: 'indigo', title: '', model: '', filter_by: '')
     limit ||= items.count
 
-    render partial: 'partials/skill_badges', locals: {color: color, items: items, limit: limit, title: title, model: model, filter_by: filter_by}
+    render partial: 'partials/skill_badges', locals: { color: color, items: items, limit: limit, title: title, model: model, filter_by: filter_by }
   end
 
   def sort_drop_down(&block)
@@ -177,5 +177,4 @@ module ApplicationHelper
 
     "gtag('event', '#{event}', {'event_category': 'Actions'});".html_safe
   end
-
 end

--- a/app/helpers/registrations_helper.rb
+++ b/app/helpers/registrations_helper.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+
 module RegistrationsHelper
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -2,6 +2,6 @@ class Offer < ApplicationRecord
   belongs_to :user
 
   def to_param
-    [id, name.parameterize].join("-")
+    [id, name.parameterize].join('-')
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -5,7 +5,7 @@ class Project < ApplicationRecord
 
   validates :name, presence: true
   validates :short_description, length: { maximum: 129 }
-  
+
   has_many :volunteers, dependent: :destroy
   has_many :volunteered_users, through: :volunteers, source: :user, dependent: :destroy
 
@@ -35,7 +35,7 @@ class Project < ApplicationRecord
   end
 
   def to_param
-    [id, name.parameterize].join("-")
+    [id, name.parameterize].join('-')
   end
 
   def volunteer_emails
@@ -46,7 +46,7 @@ class Project < ApplicationRecord
     volunteered_users.count
   end
 
-  def serializable_hash(options={})
+  def serializable_hash(options = {})
     super(
       only: [
         :id,

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module CovidVolunteers
     # the framework and any gems in your application.
 
     # Don't add field_with_errors class.
-    config.action_view.field_error_proc = Proc.new do |html_tag, instance| 
+    config.action_view.field_error_proc = Proc.new do |html_tag, instance|
       html_tag
     end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { :host => 'localhost:3000', protocol: 'http' }
+  config.action_mailer.default_url_options = { host: 'localhost:3000', protocol: 'http' }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,10 +68,10 @@ Rails.application.configure do
 
   aws_credentials = Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
   Aws::Rails.add_action_mailer_delivery_method(:aws_ses, credentials: aws_credentials, region: ENV['AWS_REGION'])
-  
+
   config.action_mailer.delivery_method = :aws_ses
 
-  config.action_mailer.default_url_options = { :host => 'helpwithcovid.com', protocol: 'http' }
+  config.action_mailer.default_url_options = { host: 'helpwithcovid.com', protocol: 'http' }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
@@ -87,7 +87,7 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -51,5 +51,4 @@ Config.setup do |config|
   #   required(:age).maybe(:int?)
   #   required(:email).filled(format?: EMAIL_REGEX)
   # end
-
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,20 +4,20 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
+min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch('PORT') { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch('RAILS_ENV') { 'development' }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # Redirect www to non-www.
   if ENV['CANONICAL_HOST']
-    constraints(:host => Regexp.new("^(?!#{Regexp.escape(ENV['CANONICAL_HOST'])})")) do
+    constraints(host: Regexp.new("^(?!#{Regexp.escape(ENV['CANONICAL_HOST'])})")) do
       match '/(*path)' => redirect { |params, req| "https://#{ENV['CANONICAL_HOST']}/#{params[:path]}" },  via: [ :get, :post, :put, :delete ]
     end
   end

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,6 +1,6 @@
 Spring.watch(
-  ".ruby-version",
-  ".rbenv-vars",
-  "tmp/restart.txt",
-  "tmp/caching-dev.txt"
+  '.ruby-version',
+  '.rbenv-vars',
+  'tmp/restart.txt',
+  'tmp/caching-dev.txt'
 )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -67,11 +67,11 @@ project4 = Project.create(user: user, status: ALL_PROJECT_STATUS.shuffle.first, 
 project5 = Project.create(user: user, status: ALL_PROJECT_STATUS.shuffle.first, name: 'Selfie lenses to spread public health into in a fun way project ', description: %{We are a group called Lefty Lenses who have been applying selfie lenses (like the Snapchat puppy filter) to politics for the 2020 election. Our lenses have reached 125M people in 10 weeks, and we've spent $0.}, accepting_volunteers: true, highlight: true)
 
 # VOLUNTEERS
-project1.volunteered_users << user3
-project3.volunteered_users << user
-project3.volunteered_users << user2
-project3.volunteered_users << user3
-project3.volunteered_users << user4
+project1.volunteered_users << [user3]
+project2.volunteered_users << []
+project3.volunteered_users << [user, user2, user3, user4]
+project4.volunteered_users << [user4, user5]
+project5.volunteered_users << [user5, user6]
 
 # SKILLS
 project1.skill_list.add('Design')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -39,12 +39,12 @@ user6 = User.create!(email: 'user6@gmail.com', name: 'jamiew', password: 'passwo
 
 # PROJECTS
 project1 = user.projects.create(
-  status: ALL_PROJECT_STATUS.shuffle.first, 
-  name: 'Act Now Foundation - Import & distribution of 10-minute at home COVID-19 test kits', 
-  target_location: 'USA', 
+  status: ALL_PROJECT_STATUS.shuffle.first,
+  name: 'Act Now Foundation - Import & distribution of 10-minute at home COVID-19 test kits',
+  target_location: 'USA',
   volunteer_location: 'Anywhere',
-  description: 'A cool description', 
-  accepting_volunteers: true, 
+  description: 'A cool description',
+  accepting_volunteers: true,
   highlight: true)
 project1.skill_list.add('Anything')
 project1.volunteered_users << user3
@@ -97,4 +97,3 @@ project2.save
 project3.save
 project4.save
 project5.save
-

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe AdminController, type: :controller do
-  let!(:user){ FactoryBot.create(:user) }
-  let!(:admin){ User.where(email: ADMINS[0]).first || FactoryBot.create(:user, email: ADMINS[0]) }
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:admin) { User.where(email: ADMINS[0]).first || FactoryBot.create(:user, email: ADMINS[0]) }
 
   describe 'POST #delete_user' do
-    let!(:valid_params){ { user_id: user.to_param } }
+    let!(:valid_params) { { user_id: user.to_param } }
 
     # TODO refactor to account for shared `ensure_admin` filter
     # Then just test that each method calls `ensure_admin`, like so
@@ -43,8 +43,8 @@ RSpec.describe AdminController, type: :controller do
   end
 
   describe 'POST #toggle_highlight' do
-    let!(:project){ FactoryBot.create(:project, user: user) }
-    let!(:valid_params){ { project_id: project.to_param} }
+    let!(:project) { FactoryBot.create(:project, user: user) }
+    let!(:valid_params) { { project_id: project.to_param } }
 
     it 'calls ensure_admin' do
       expect(controller).to receive(:ensure_admin)
@@ -70,5 +70,4 @@ RSpec.describe AdminController, type: :controller do
       expect(flash[:notice]).to match(/Removed highlight/)
     end
   end
-
 end

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe OffersController, type: :controller do
-
   describe 'GET #index' do
     it 'works' do
       pending 'TODO'
@@ -10,8 +9,8 @@ RSpec.describe OffersController, type: :controller do
   end
 
   describe 'GET #show' do
-    let!(:user){ FactoryBot.create(:user) }
-    let!(:offer){ FactoryBot.create(:offer, user: user) }
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:offer) { FactoryBot.create(:offer, user: user) }
 
     it 'works with just a numeric id as param' do
       get :show, params: { id: offer.id }
@@ -62,5 +61,4 @@ RSpec.describe OffersController, type: :controller do
       fail
     end
   end
-
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -149,7 +149,6 @@ RSpec.describe ProjectsController, type: :controller do
       # expect(session[:track_event]).to eq('Project creation started')
       expect(response.body).to match(/Project creation started/)
     end
-
   end
 
   describe 'GET #edit' do
@@ -212,7 +211,5 @@ RSpec.describe ProjectsController, type: :controller do
       pending 'TODO'
       fail
     end
-
   end
-
 end

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -26,6 +26,4 @@ RSpec.describe Users::RegistrationsController do
       fail
     end
   end
-
-
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -39,10 +39,10 @@ FactoryBot.define do
   end
 
   factory :offer do
-    name { "Free Veggie Burgers" }
+    name { 'Free Veggie Burgers' }
     description { "They're delicious and animal-free" }
-    limitations { "Contains gluten" }
-    redemption { "https://veggieboigas.com" }
-    location { "N/A" }
+    limitations { 'Contains gluten' }
+    redemption { 'https://veggieboigas.com' }
+    location { 'N/A' }
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ApplicationHelper do
 
   it 'gets query params' do
     params = get_query_params
-    desired_params = {'skills'=>['Biology', 'Software'], 'project_types'=>['Track the outbreak', 'Reduce spread'], 'filters_open'=>['true']}
+    desired_params = { 'skills'=>['Biology', 'Software'], 'project_types'=>['Track the outbreak', 'Reduce spread'], 'filters_open'=>['true'] }
     assert params.eql? desired_params
   end
 
@@ -24,13 +24,13 @@ RSpec.describe ApplicationHelper do
 
   it 'toggles a filter on' do
     toggled_on = toggle_filter('skills', 'JellyFishing')
-    desired_params = {'skills'=>['Biology', 'Software', 'JellyFishing'], 'project_types'=>['Track the outbreak', 'Reduce spread'], 'filters_open'=>['true']}
+    desired_params = { 'skills'=>['Biology', 'Software', 'JellyFishing'], 'project_types'=>['Track the outbreak', 'Reduce spread'], 'filters_open'=>['true'] }
     assert toggled_on.eql? desired_params
   end
 
   it 'toggles a filter off' do
     toggled_on = toggle_filter('skills', 'Biology')
-    desired_params = {'skills'=>['Software'], 'project_types'=>['Track the outbreak', 'Reduce spread'], 'filters_open'=>['true']}
+    desired_params = { 'skills'=>['Software'], 'project_types'=>['Track the outbreak', 'Reduce spread'], 'filters_open'=>['true'] }
     assert toggled_on.eql? desired_params
   end
 
@@ -69,5 +69,4 @@ RSpec.describe ApplicationHelper do
       expect(google_analytics_id).to eq('UA-162054776-1')
     end
   end
-
 end

--- a/spec/mailers/project_mailer_spec.rb
+++ b/spec/mailers/project_mailer_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe ProjectMailer, type: :mailer do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Volunteer, type: :model do
-  let!(:user){ FactoryBot.create(:user) }
-  let!(:project){ FactoryBot.create(:project, user: user) }
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:project) { FactoryBot.create(:project, user: user) }
 
-  it "factory is valid, given valid associations" do
+  it 'factory is valid, given valid associations' do
     # Note that user is volunteering for their own project, but this is allowed
     volunteer = FactoryBot.build(:volunteer, user: user, project: project)
     expect(volunteer.valid?).to eq(true)
@@ -19,5 +19,4 @@ RSpec.describe Volunteer, type: :model do
     volunteer = FactoryBot.build(:volunteer, user: user, project: nil)
     expect(volunteer.valid?).to eq(false)
   end
-
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'devise'
@@ -62,9 +62,9 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   # Devise/Warden
-  config.include Devise::Test::ControllerHelpers, :type => :controller
+  config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Warden::Test::Helpers
-  config.include Devise::Test::IntegrationHelpers, :type => :request
+  config.include Devise::Test::IntegrationHelpers, type: :request
 
   config.include FactoryBot::Syntax::Methods
 end

--- a/spec/requests/admin/volunteer_groups_request_spec.rb
+++ b/spec/requests/admin/volunteer_groups_request_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
-RSpec.describe "Admin::VolunteerGroups", type: :request do
-
+RSpec.describe 'Admin::VolunteerGroups', type: :request do
 end

--- a/spec/requests/admin_request_spec.rb
+++ b/spec/requests/admin_request_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
-RSpec.describe "Admins", type: :request do
-
+RSpec.describe 'Admins', type: :request do
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 RSpec.configure do |config|
-
   # rspec-expectations config
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -67,5 +66,4 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
-
 end


### PR DESCRIPTION
* Ignore auto-generated files like db/schema.rb and heavily-scaffolded files like db/migrate/*
* Let rubocop try and automatically fix things: `bundle exec rubocop -a`
* Fix the things rubocop broke (one "nd" statement)
* Add rubocop style enforcement to the build process, so future PRs will be red if they need
  either functional or stylistic changes