### PR TITLE
Fix will_paginate deprecation warning

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -19,8 +19,8 @@ class ProjectsController < ApplicationController
 
         @projects = @projects.page(params[:page]).per(25)
 
-        @index_from = (@projects.prev_page || 0) * @projects.current_per_page + 1
-        @index_to = [@index_from + @projects.current_per_page - 1, @projects.total_count].min
+        @index_from = (@projects.prev_page || 0) * @projects.limit_value + 1
+        @index_to = [@index_from + @projects.limit_value - 1, @projects.total_count].min
         @total_count = @projects.total_count
       end
       format.json do


### PR DESCRIPTION
While we're linting things... no more of this in the test suite output:

```
DEPRECATION WARNING: #current_per_page is deprecated and will be removed in the next major version. Please use #limit_value instead.
```

To confirm:

```
bundle exec rake && bundle exec rubocop && echo 'All is good' || echo 'You broke something'
```