### PR TITLE
Setup circle ci config to use workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,11 @@ jobs: # a collection of steps
           # command: bin/rails db:schema:load --trace
           command: bin/rails db:setup --trace
 
+  test:
+    docker: # run the steps with Docker
+      - image: circleci/ruby:2.6.3-stretch-node # ...with this image as the primary container; this is where all `steps` will run
+    steps:
+      - checkout    
       - run:
           name: Run rspec in parallel
           command: |
@@ -76,13 +81,29 @@ jobs: # a collection of steps
                               --out test_results/rspec.xml \
                               --format progress \
                               $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
-
       # Save test results for timing analysis
       - store_test_results: # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
           path: test_results
 
+  rubocop:
+    docker: # run the steps with Docker
+      - image: circleci/ruby:2.6.3-stretch-node # ...with this image as the primary container; this is where all `steps` will run
+    steps:
+      - checkout
       - run:
           name: Rubocop
           command: bundle exec rubocop
 
-      # See https://circleci.com/docs/2.0/deployment-integrations/ for example deploy configs
+workflows:
+  version: 2
+  build-and-test:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build
+      - rubocop:
+          requires:
+            - build
+
+# See https://circleci.com/docs/2.0/deployment-integrations/ for example deploy configs


### PR DESCRIPTION
Addresses comment from Discord: https://discordapp.com/channels/689552739797434432/689658307392307306/700117137012031589

Currently our Circle CI setup runs one long job which does many things in consecutive order:
- build the app
- run tests
- run rubocop

This PR sets up circle ci to use its '[workflows](https://circleci.com/docs/2.0/workflows/)' feature. Using workflows, we can split out the one big all-encompassing job into seperate jobs for each thing listed above.

I've also noticed that we currently run rubocop after we've finished tests. I've setup workflows to run these two jobs in parallel as I don't think one depends on the other. This could speed delployment 🤞🏾