### PR TITLE
Use FactoryBot shorthand to save typing strokes.

### DIFF
--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe AdminController, type: :controller do
-  let!(:user) { FactoryBot.create(:user) }
-  let!(:admin) { User.where(email: ADMINS[0]).first || FactoryBot.create(:user, email: ADMINS[0]) }
+  let!(:user) { create(:user) }
+  let!(:admin) { User.where(email: ADMINS[0]).first || create(:user, email: ADMINS[0]) }
 
   describe 'POST #delete_user' do
     let!(:valid_params) { { user_id: user.to_param } }
@@ -43,7 +43,7 @@ RSpec.describe AdminController, type: :controller do
   end
 
   describe 'POST #toggle_highlight' do
-    let!(:project) { FactoryBot.create(:project, user: user) }
+    let!(:project) { create(:project, user: user) }
     let!(:valid_params) { { project_id: project.to_param } }
 
     it 'calls ensure_admin' do
@@ -62,7 +62,7 @@ RSpec.describe AdminController, type: :controller do
 
     it 'unhighlights if project was already highlighted' do
       sign_in(admin)
-      active_project = FactoryBot.create(:project, user: user, highlight: true)
+      active_project = create(:project, user: user, highlight: true)
       expect(active_project.highlight?).to eq(true)
       post :toggle_highlight, params: { project_id: active_project.to_param }
       expect(response).to redirect_to(project_path(active_project))

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe HomeController, type: :controller do
   render_views
 
-  let!(:user) { FactoryBot.create(:user) }
-  let!(:project) { FactoryBot.create(:project, user: user, highlight: true) }
+  let!(:user) { create(:user) }
+  let!(:project) { create(:project, user: user, highlight: true) }
 
   describe '#index' do
     it 'works' do
@@ -22,7 +22,7 @@ RSpec.describe HomeController, type: :controller do
     end
 
     it 'doesnt show the same featured project twice' do
-      project2 = FactoryBot.create(:project_with_type, user: user, highlight: true, project_type_list: ['Track the outbreak', 'Scale testing'])
+      project2 = create(:project_with_type, user: user, highlight: true, project_type_list: ['Track the outbreak', 'Scale testing'])
       get :index
       featured_ids = assigns(:project_groups).map(&:featured_projects).flatten.map(&:id)
       expect(featured_ids.count(project2.id)).to eq(1)

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe OffersController, type: :controller do
   end
 
   describe 'GET #show' do
-    let!(:user) { FactoryBot.create(:user) }
-    let!(:offer) { FactoryBot.create(:offer, user: user) }
+    let!(:user) { create(:user) }
+    let!(:offer) { create(:offer, user: user) }
 
     it 'works with just a numeric id as param' do
       get :show, params: { id: offer.id }

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe ProjectsController, type: :controller do
   render_views
 
-  let!(:user) { FactoryBot.create(:user) }
-  let!(:project) { FactoryBot.create(:project, user: user) }
+  let!(:user) { create(:user) }
+  let!(:project) { create(:project, user: user) }
   let(:valid_params) { { project: { name: 'My Project Name', status: ALL_PROJECT_STATUS.first } } }
 
   describe 'GET #index' do
@@ -24,7 +24,7 @@ RSpec.describe ProjectsController, type: :controller do
     end
 
     describe 'Volunteering' do
-      let!(:no_volunteers_project) { FactoryBot.create(:project, user: user, accepting_volunteers: false) }
+      let!(:no_volunteers_project) { create(:project, user: user, accepting_volunteers: false) }
 
       it 'filters by ?accepting_volunteers=0' do
         get :index, params: { accepting_volunteers: '0' }
@@ -54,7 +54,7 @@ RSpec.describe ProjectsController, type: :controller do
 
       it 'shows projects filtered by status' do
         project.update_attribute(:status, ALL_PROJECT_STATUS.last)
-        project2 = FactoryBot.create(:project, user: user, status: ALL_PROJECT_STATUS.first)
+        project2 = create(:project, user: user, status: ALL_PROJECT_STATUS.first)
         get :index, params: { status: ALL_PROJECT_STATUS.last }
         expect(assigns(:projects)).to include(project)
         expect(assigns(:projects)).to_not include(project2)
@@ -63,7 +63,7 @@ RSpec.describe ProjectsController, type: :controller do
 
     it 'shows highlighted projects only' do
       project.update_attribute(:highlight, true)
-      reg_project = FactoryBot.create(:project, user: user, highlight: false)
+      reg_project = create(:project, user: user, highlight: false)
       get :index, params: { highlight: true }
       expect(response).to be_successful
       expect(assigns(:projects)).to include(project)
@@ -110,7 +110,7 @@ RSpec.describe ProjectsController, type: :controller do
       end
 
       it 'shows volunteer button if your profile is complete' do
-        user = FactoryBot.create(:user_complete_profile)
+        user = create(:user_complete_profile)
         sign_in user
         user.skill_list.add('Design')
         user.save
@@ -121,7 +121,7 @@ RSpec.describe ProjectsController, type: :controller do
       end
 
       it 'shows volunteer filled button if you dont have the right skills' do
-        user = FactoryBot.create(:user_complete_profile)
+        user = create(:user_complete_profile)
         sign_in user
         get :show, params: { id: project.to_param }
         expect(response.body).to include('volunteers-filled-btn')

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Offer, type: :model do
   it 'factory is valid' do
-    user = FactoryBot.create(:user)
-    offer = FactoryBot.build(:offer, user: user)
+    user = create(:user)
+    offer = build(:offer, user: user)
     expect(offer).to be_valid
   end
 
   it 'is invalid without a user' do
-    offer = FactoryBot.build(:offer, user: nil)
+    offer = build(:offer, user: nil)
     expect(offer).to_not be_valid
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,27 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe Project, type: :model do
-  let(:user) { FactoryBot.build(:user) }
-  let(:project) { FactoryBot.build(:project, user: user) }
+  let(:user) { build(:user) }
+  let(:project) { build(:project, user: user) }
 
   it 'factory is valid' do
-    user = FactoryBot.create(:user)
-    project = FactoryBot.build(:project, user: user)
+    user = create(:user)
+    project = build(:project, user: user)
     expect(project).to be_valid
   end
 
   it 'is invalid without a name' do
-    project = FactoryBot.build(:project, name: nil)
+    project = build(:project, name: nil)
     expect(project).to_not be_valid
   end
 
   it 'is invalid without a user' do
-    project = FactoryBot.build(:project, user: nil)
+    project = build(:project, user: nil)
     expect(project).to_not be_valid
   end
 
   it 'accepting_volunteers defaults true' do
-    project = FactoryBot.build(:project, user: nil)
+    project = build(:project, user: nil)
     expect(project.accepting_volunteers).to eq(true)
   end
 
@@ -50,18 +50,18 @@ RSpec.describe Project, type: :model do
   end
 
   it 'it sets default status' do
-    project = FactoryBot.build(:project, status: nil)
+    project = build(:project, status: nil)
     project.save
     expect(project.status).to eq(ALL_PROJECT_STATUS.first)
   end
 
   it 'is invalid without a status' do
-    project = FactoryBot.build(:project, status: nil)
+    project = build(:project, status: nil)
     expect(project).to_not be_valid
   end
 
   it 'is invalid with wrong status' do
-    project = FactoryBot.build(:project, status: 'lol')
+    project = build(:project, status: 'lol')
     expect(project).to_not be_valid
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,32 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  let(:user) { FactoryBot.build(:user) }
-  let(:project) { FactoryBot.build(:project, user: user) }
+  let(:user) { build(:user) }
+  let(:project) { build(:project, user: user) }
 
   it 'factory is valid' do
-    user = FactoryBot.build(:user)
+    user = build(:user)
     expect(user).to be_valid
   end
 
   it 'is invalid without email' do
-    user = FactoryBot.build(:user, email: nil)
+    user = build(:user, email: nil)
     expect(user).to_not be_valid
   end
 
   it 'is invalid without password' do
-    user = FactoryBot.build(:user, password: nil)
+    user = build(:user, password: nil)
     expect(user).to_not be_valid
   end
 
   describe 'Complete profile' do
     it 'is incomplete' do
-      user = FactoryBot.build(:user, profile_links: 'test', location: 'test')
+      user = build(:user, profile_links: 'test', location: 'test')
       expect(user.has_complete_profile?).to eq(false)
     end
 
     it 'is complete' do
-      user = FactoryBot.build(:user, about: 'test', profile_links: 'test', location: 'test')
+      user = build(:user, about: 'test', profile_links: 'test', location: 'test')
       expect(user.has_complete_profile?).to eq(true)
     end
 

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -1,22 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Volunteer, type: :model do
-  let!(:user) { FactoryBot.create(:user) }
-  let!(:project) { FactoryBot.create(:project, user: user) }
+  let!(:user) { create(:user) }
+  let!(:project) { create(:project, user: user) }
 
   it 'factory is valid, given valid associations' do
     # Note that user is volunteering for their own project, but this is allowed
-    volunteer = FactoryBot.build(:volunteer, user: user, project: project)
+    volunteer = build(:volunteer, user: user, project: project)
     expect(volunteer.valid?).to eq(true)
   end
 
   it 'is invalid without a user' do
-    volunteer = FactoryBot.build(:volunteer, user: nil, project: project)
+    volunteer = build(:volunteer, user: nil, project: project)
     expect(volunteer.valid?).to eq(false)
   end
 
   it 'is invalid without a project' do
-    volunteer = FactoryBot.build(:volunteer, user: user, project: nil)
+    volunteer = build(:volunteer, user: user, project: nil)
     expect(volunteer.valid?).to eq(false)
   end
 end


### PR DESCRIPTION
This just introduces the FactoryBot shorthand, allowing us to replace...

`FactoryBot.create(:some_factory)`

with

`create(:some_factory)`

