### PR TITLE
Refactor tests and add skill_set to factory :user_complete_profile

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
     about { 'About' }
     profile_links { 'Profile' }
     location { 'location' }
+    skill_list { ['Analaytics'] }
   end
 
   factory :project do


### PR DESCRIPTION
I've refactored tests to correctly use `let` and `context` blocks to avoid code duplication and overly long `it` blocks.

I've also added the `skill_set` attribute to the `:user_complete_profile` factory, as this was made a required profile field in a [previous PR](https://github.com/helpwithcovid/covid-volunteers/pull/159).