### PR TITLE
Finish offer controller spec

### DIFF
--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe OffersController, type: :controller do
       expect(response).to_not render_template(:partial => '_global-announcements')
     end
   end
+
+  shared_examples 'an unsuccessful request' do
+    it 'is unsuccessful' do
+      expect(response).not_to be_successful
+    end 
+  end
   
   describe 'GET #index' do
     let!(:offer) { create(:offer, name: 'Free books', user: user) }
@@ -70,10 +76,8 @@ RSpec.describe OffersController, type: :controller do
 
     context 'when user is not signed in' do
       before { get :new }
-
-      it 'is unsuccessful' do
-        expect(response).not_to be_successful
-      end      
+      
+      it_behaves_like 'an unsuccessful request'
     end
 
     context 'when user is signed-in' do
@@ -106,9 +110,7 @@ RSpec.describe OffersController, type: :controller do
     context 'when user is not signed in' do
       before { get :edit, params: { id: offer.id } }
 
-      it 'is unsuccessful' do
-        expect(response).not_to be_successful
-      end      
+      it_behaves_like 'an unsuccessful request'
     end
 
     context 'when user is signed-in' do
@@ -164,9 +166,7 @@ RSpec.describe OffersController, type: :controller do
     context 'when user is not signed in' do
       before { post :create, params: { offer: { name: 'name', description: 'desc', limitations: 'limit', redemption: 'red', location: 'loc'} } }
 
-      it 'is unsuccessful' do
-        expect(response).not_to be_successful
-      end      
+      it_behaves_like 'an unsuccessful request'
     end
 
     context 'when user is signed-in' do
@@ -190,9 +190,7 @@ RSpec.describe OffersController, type: :controller do
     context 'when user is not signed in' do
       before { put :update, params: { id: offer.id, name: 'a new name' } }
 
-      it 'is unsuccessful' do
-        expect(response).not_to be_successful
-      end      
+      it_behaves_like 'an unsuccessful request'    
     end
 
     context 'when user is signed in' do
@@ -229,9 +227,7 @@ RSpec.describe OffersController, type: :controller do
     context 'when user is not signed in' do
       before { post :destroy, params: { id: offer.id } }
 
-      it 'is unsuccessful' do
-        expect(response).not_to be_successful
-      end      
+      it_behaves_like 'an unsuccessful request'     
     end
 
     context 'when user is signed-in' do

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe OffersController, type: :controller do
   end
 
   describe 'GET #show' do
-    let!(:user) { create(:user) }
+    let(:user) { create(:user) }
     let!(:offer) { create(:offer, user: user) }
 
     it 'works with just a numeric id as param' do
@@ -101,30 +101,37 @@ RSpec.describe OffersController, type: :controller do
 
   describe 'POST #create' do
     let(:user) { create(:user) }
-    let(:offer) { create(:offer, user: user) }
-
-    before { allow(Offer).to receive(:new).and_return(offer)}
 
     it 'works' do
       sign_in user
-      post :create, params: { offer: { name: offer.name, description: 'desc', limitations: 'limit', redemption: 'red', location: 'loc'} }
+      post :create, params: { offer: { name: 'name', description: 'desc', limitations: 'limit', redemption: 'red', location: 'loc'} }
 
-      expect(response).to redirect_to(offer_path(assigns(:offer)))
+      expect(response).to redirect_to(offer_path(assigns(:offer))) #Can't think of a better wato test this...
     end
   end
 
   describe 'PUT #update' do
+    let(:user) { create(:user) }
+    let(:offer) { create(:offer, user: user) }
+
     it 'works' do
-      pending 'TODO'
-      fail
+      sign_in user
+      put :update, params: { id: offer.id, name: 'a new name' }
+
+      expect(response).to redirect_to(offer_path(offer))
     end
   end
 
 
   describe 'DELETE #destroy' do
+    let(:user) { create(:user) }
+    let(:offer) { create(:offer, user: user) }
+
     it 'works' do
-      pending 'TODO'
-      fail
+      sign_in user
+      post :destroy, params: { id: offer.id }
+
+      expect(response).to redirect_to(offers_path)
     end
   end
 end

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -41,9 +41,31 @@ RSpec.describe OffersController, type: :controller do
   end
 
   describe 'GET #new' do
-    it 'works' do
-      pending 'TODO'
-      fail
+    let(:user) { create(:user) }
+
+    it 'is successful' do
+      
+      sign_in user
+
+      get :new
+
+      expect(response).to be_successful
+    end
+
+    it 'assigns an offer' do
+      sign_in user
+
+      get :new
+
+      expect(assigns(:offer)).to be_an_instance_of(Offer)
+    end
+
+    it 'displays form for creating an offer' do
+      sign_in user
+
+      get :new 
+      
+      expect(response.body).to include('Create new resource')     
     end
   end
 

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -70,9 +70,32 @@ RSpec.describe OffersController, type: :controller do
   end
 
   describe 'GET #edit' do
-    it 'works' do
-      pending 'TODO'
-      fail
+    let(:offer) { create(:offer, user: user) }
+    let(:user) { create(:user) }
+
+    it 'is successful' do
+      
+      sign_in user
+
+      get :edit, params: { id: offer.id }
+
+      expect(response).to be_successful
+    end
+
+    it 'assigns the offer' do
+      sign_in user
+
+      get :edit, params: { id: offer.id }
+
+      expect(assigns(:offer)).to eq(offer)
+    end
+
+    it 'displays form for creating an offer' do
+      sign_in user
+
+      get :edit, params: { id: offer.id  }
+      
+      expect(response.body).to include("Edit resource #{offer.name}")     
     end
   end
 

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -63,23 +63,32 @@ RSpec.describe OffersController, type: :controller do
   describe 'GET #new' do
     let(:user) { create(:user) }
 
-    
-    before do 
-      sign_in user
+    context 'when user is not signed in' do
+      before { get :new }
 
-      get :new
+      it 'is unsuccessful' do
+        expect(response).not_to be_successful
+      end      
     end
 
-    it 'is successful' do
-      expect(response).to be_successful
-    end
+    context 'when user is signed-in' do
+      before do 
+        sign_in user
 
-    it 'assigns an offer' do
-      expect(assigns(:offer)).to be_an_instance_of(Offer)
-    end
+        get :new
+      end
 
-    it 'renders form for creating an offer' do
-      expect(response.body).to include('Create new resource')     
+      it 'is successful' do
+        expect(response).to be_successful
+      end
+
+      it 'assigns an offer' do
+        expect(assigns(:offer)).to be_an_instance_of(Offer)
+      end
+
+      it 'renders form for creating an offer' do
+        expect(response.body).to include('Create new resource')     
+      end
     end
   end
 
@@ -87,33 +96,77 @@ RSpec.describe OffersController, type: :controller do
     let(:offer) { create(:offer, user: user) }
     let(:user) { create(:user) }
 
-    before do
-      sign_in user
+    context 'when user is not signed in' do
+      before { get :edit, params: { id: offer.id } }
 
-      get :edit, params: { id: offer.id }
+      it 'is unsuccessful' do
+        expect(response).not_to be_successful
+      end      
     end
 
-    it 'is successful' do
-      expect(response).to be_successful
+    context 'when user is signed-in' do
+      before do
+        sign_in user
+
+        get :edit, params: { id: offer.id }
+      end
+
+      it 'is successful' do
+        expect(response).to be_successful
+      end
+
+      it 'assigns the offer' do
+        expect(assigns(:offer)).to eq(offer)
+      end
+
+      it 'renders form for creating an offer' do
+        expect(response.body).to include("Edit resource #{offer.name}")     
+      end
     end
 
-    it 'assigns the offer' do
-      expect(assigns(:offer)).to eq(offer)
-    end
+    context 'when admin is signed-in' do
+      let (:admin) { create(:user, email: ADMINS[0]) }
 
-    it 'renders form for creating an offer' do
-      expect(response.body).to include("Edit resource #{offer.name}")     
+      before do
+        sign_in admin
+
+        get :edit, params: { id: offer.id }
+      end
+
+      it 'is successful' do
+        expect(response).to be_successful
+      end
+
+      it 'assigns the offer' do
+        expect(assigns(:offer)).to eq(offer)
+      end
+
+      it 'renders form for creating an offer' do
+        expect(response.body).to include("Edit resource #{offer.name}")     
+      end
     end
   end
 
   describe 'POST #create' do
     let(:user) { create(:user) }
 
-    it 'redirects to the offer' do
-      sign_in user
-      post :create, params: { offer: { name: 'name', description: 'desc', limitations: 'limit', redemption: 'red', location: 'loc'} }
+    context 'when user is not signed in' do
+      before { post :create, params: { offer: { name: 'name', description: 'desc', limitations: 'limit', redemption: 'red', location: 'loc'} } }
 
-      expect(response).to redirect_to(offer_path(assigns(:offer))) #Can't think of a better wato test this...
+      it 'is unsuccessful' do
+        expect(response).not_to be_successful
+      end      
+    end
+
+    context 'when user is signed-in' do
+      before do
+        sign_in user
+        post :create, params: { offer: { name: 'name', description: 'desc', limitations: 'limit', redemption: 'red', location: 'loc'} }
+      end
+
+      it 'redirects to the offer' do
+        expect(response).to redirect_to(offer_path(assigns(:offer))) #Can't think of a better wato test this...
+      end
     end
   end
 
@@ -121,24 +174,72 @@ RSpec.describe OffersController, type: :controller do
     let(:user) { create(:user) }
     let(:offer) { create(:offer, user: user) }
 
-    it 'redirects to the offer' do
-      sign_in user
-      put :update, params: { id: offer.id, name: 'a new name' }
+    context 'when user is not signed in' do
+      before { put :update, params: { id: offer.id, name: 'a new name' } }
 
-      expect(response).to redirect_to(offer_path(offer))
+      it 'is unsuccessful' do
+        expect(response).not_to be_successful
+      end      
     end
-  end
 
+    context 'when user is signed in' do
+      before do
+        sign_in user
+        put :update, params: { id: offer.id, name: 'a new name' }
+      end
+
+      it 'redirects to the offer' do
+        expect(response).to redirect_to(offer_path(offer))
+      end
+    end
+
+    context 'when admin is signed in' do
+      let (:admin) { create(:user, email: ADMINS[0]) }
+
+      before do
+        sign_in admin
+        put :update, params: { id: offer.id, name: 'a new name' }
+      end
+
+      it 'redirects to the offer' do
+        expect(response).to redirect_to(offer_path(offer))
+      end
+    end    
+  end
 
   describe 'DELETE #destroy' do
     let(:user) { create(:user) }
     let(:offer) { create(:offer, user: user) }
 
-    it 'it redirects to the offers' do
-      sign_in user
-      post :destroy, params: { id: offer.id }
+    context 'when user is not signed in' do
+      before { post :destroy, params: { id: offer.id } }
 
-      expect(response).to redirect_to(offers_path)
+      it 'is unsuccessful' do
+        expect(response).not_to be_successful
+      end      
+    end
+
+    context 'when user is signed-in' do
+      before do
+        sign_in user
+        post :destroy, params: { id: offer.id }
+      end
+      it 'it redirects to the offers' do
+        expect(response).to redirect_to(offers_path)
+      end
+    end
+
+    context 'when admin is signed in' do
+      let (:admin) { create(:user, email: ADMINS[0]) }
+
+      before do
+        sign_in admin
+        post :destroy, params: { id: offer.id }
+      end
+
+      it 'redirects to the offer' do
+        expect(response).to redirect_to(offers_path)
+      end
     end
   end
 end

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -17,83 +17,91 @@ RSpec.describe OffersController, type: :controller do
       expect(assigns(:offers)).to eq([offer])
     end
 
-    it 'renders the offer' do
+    it 'renders offers' do
       expect(response.body).to include('Free books')
     end
   end
 
   describe 'GET #show' do
     let(:user) { create(:user) }
-    let!(:offer) { create(:offer, user: user) }
+    let!(:offer) { create(:offer, name: 'Free coffee', user: user) }
 
-    it 'works with just a numeric id as param' do
-      get :show, params: { id: offer.id }
-      expect(response).to be_successful
-      expect(assigns(:offer)).to eq(offer)
+    context 'with a numeric id as param' do
+      before { get :show, params: { id: offer.id } }
+      
+      it 'is successful' do
+        expect(response).to be_successful
+      end
+      
+      it 'assigns the offer' do
+        expect(assigns(:offer)).to eq(offer)
+      end
+
+      it 'renders the offer' do
+        expect(response.body).to include('Free coffee')
+      end 
+      
     end
 
-    it 'works with a "5-my-offer-name" param too' do #why do we need a named param if we can retrieve a resource by its id?
-      get :show, params: { id: offer.to_param }
-      expect(response).to be_successful
-      expect(assigns(:offer)).to eq(offer)
+    context 'with a parameterize id' do 
+      before { get :show, params: { id: offer.to_param } }
+      
+      it 'is successful' do
+        expect(response).to be_successful
+      end
+
+      it 'assigns the offer' do
+        expect(assigns(:offer)).to eq(offer)
+      end
+
+      it 'renders the offer' do
+        expect(response.body).to include('Free coffee')
+      end 
     end
   end
 
   describe 'GET #new' do
     let(:user) { create(:user) }
 
-    it 'is successful' do
-      
+    
+    before do 
       sign_in user
 
       get :new
+    end
 
+    it 'is successful' do
       expect(response).to be_successful
     end
 
     it 'assigns an offer' do
-      sign_in user
-
-      get :new
-
       expect(assigns(:offer)).to be_an_instance_of(Offer)
     end
 
     it 'renders form for creating an offer' do
-      sign_in user
-
-      get :new 
-      
       expect(response.body).to include('Create new resource')     
     end
   end
 
-  describe 'GET #edit' do
+  describe 'GET #edit' do #TEST ONLY OWNER OR ADMIN, 
     let(:offer) { create(:offer, user: user) }
     let(:user) { create(:user) }
 
-    it 'is successful' do
-      
+    before do
       sign_in user
 
       get :edit, params: { id: offer.id }
+    end
 
+    it 'is successful' do
       expect(response).to be_successful
     end
 
     it 'assigns the offer' do
-      sign_in user
-
-      get :edit, params: { id: offer.id }
-
       expect(assigns(:offer)).to eq(offer)
     end
 
     it 'renders form for creating an offer' do
-      sign_in user
-
-      get :edit, params: { id: offer.id  }
-      
       expect(response.body).to include("Edit resource #{offer.name}")     
     end
   end
@@ -101,7 +109,7 @@ RSpec.describe OffersController, type: :controller do
   describe 'POST #create' do
     let(:user) { create(:user) }
 
-    it 'works' do
+    it 'redirects to the offer' do
       sign_in user
       post :create, params: { offer: { name: 'name', description: 'desc', limitations: 'limit', redemption: 'red', location: 'loc'} }
 
@@ -113,7 +121,7 @@ RSpec.describe OffersController, type: :controller do
     let(:user) { create(:user) }
     let(:offer) { create(:offer, user: user) }
 
-    it 'works' do
+    it 'redirects to the offer' do
       sign_in user
       put :update, params: { id: offer.id, name: 'a new name' }
 
@@ -126,7 +134,7 @@ RSpec.describe OffersController, type: :controller do
     let(:user) { create(:user) }
     let(:offer) { create(:offer, user: user) }
 
-    it 'works' do
+    it 'it redirects to the offers' do
       sign_in user
       post :destroy, params: { id: offer.id }
 

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -14,6 +14,16 @@ RSpec.describe OffersController, type: :controller do
       expect(response).not_to be_successful
     end 
   end
+
+  shared_examples 'a successful request' do |text|
+    it 'is successful' do
+      expect(response).to be_successful
+    end
+
+    it 'renders the correct page' do
+      expect(response.body).to include(text)
+    end
+  end
   
   describe 'GET #index' do
     let!(:offer) { create(:offer, name: 'Free books', user: user) }
@@ -21,16 +31,10 @@ RSpec.describe OffersController, type: :controller do
     
     before { get :index }
     
-    it 'is successful' do
-      expect(response).to be_successful
-    end
+    it_behaves_like 'a successful request', 'Free books'
 
     it 'assigns offers' do
       expect(assigns(:offers)).to eq([offer])
-    end
-
-    it 'renders offers' do
-      expect(response.body).to include('Free books')
     end
 
     it_behaves_like 'it does not show global announcements'
@@ -40,34 +44,30 @@ RSpec.describe OffersController, type: :controller do
     let(:user) { create(:user) }
     let!(:offer) { create(:offer, name: 'Free coffee', user: user) }
 
-    shared_examples 'it successfully completes the #show action' do
-      before { get :show, params: { id: offer_id } }
-
-      it 'is successful' do
-        expect(response).to be_successful
-      end
-      
-      it 'assigns the offer' do
-        expect(assigns(:offer)).to eq(offer)
-      end
-
-      it 'renders the offer' do
-        expect(response.body).to include('Free coffee')
-      end 
-      
-      it_behaves_like 'it does not show global announcements'
-    end
+    before { get :show, params: { id: offer_id } }
 
     context 'with a numeric id as param' do
       let(:offer_id) { offer.id } 
       
-      it_behaves_like 'it successfully completes the #show action'
+      it_behaves_like 'a successful request', 'Free coffee'
+
+      it 'assigns the offer' do
+        expect(assigns(:offer)).to eq(offer)
+      end
+      
+      it_behaves_like 'it does not show global announcements'
     end
 
     context 'with a parameterize id' do 
       let(:offer_id) { offer.to_param }
       
-      it_behaves_like 'it successfully completes the #show action'
+      it_behaves_like 'a successful request', 'Free coffee'
+
+      it 'assigns the offer' do
+        expect(assigns(:offer)).to eq(offer)
+      end
+      
+      it_behaves_like 'it does not show global announcements'
     end
   end
 
@@ -87,16 +87,10 @@ RSpec.describe OffersController, type: :controller do
         get :new
       end
 
-      it 'is successful' do
-        expect(response).to be_successful
-      end
+      it_behaves_like 'a successful request', 'Create new resource'
 
       it 'assigns an offer' do
         expect(assigns(:offer)).to be_an_instance_of(Offer)
-      end
-
-      it 'renders form for creating an offer' do
-        expect(response.body).to include('Create new resource')     
       end
 
       it_behaves_like 'it does not show global announcements'
@@ -120,16 +114,10 @@ RSpec.describe OffersController, type: :controller do
         get :edit, params: { id: offer.id }
       end
 
-      it 'is successful' do
-        expect(response).to be_successful
-      end
+      it_behaves_like 'a successful request', 'Edit resource'
 
       it 'assigns the offer' do
         expect(assigns(:offer)).to eq(offer)
-      end
-
-      it 'renders form for creating an offer' do
-        expect(response.body).to include("Edit resource #{offer.name}")     
       end
 
       it_behaves_like 'it does not show global announcements'
@@ -144,16 +132,10 @@ RSpec.describe OffersController, type: :controller do
         get :edit, params: { id: offer.id }
       end
 
-      it 'is successful' do
-        expect(response).to be_successful
-      end
+      it_behaves_like 'a successful request', 'Edit resource'
 
       it 'assigns the offer' do
         expect(assigns(:offer)).to eq(offer)
-      end
-
-      it 'renders form for creating an offer' do
-        expect(response.body).to include("Edit resource #{offer.name}")     
       end
 
       it_behaves_like 'it does not show global announcements'

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe OffersController, type: :controller do
   render_views
 
+  shared_examples 'it does not show global announcements' do
+    it 'does not show global announcements' do
+      expect(response).to_not render_template(:partial => '_global-announcements')
+    end
+  end
+  
   describe 'GET #index' do
     let!(:offer) { create(:offer, name: 'Free books', user: user) }
     let(:user) { create(:user) }
@@ -20,15 +26,17 @@ RSpec.describe OffersController, type: :controller do
     it 'renders offers' do
       expect(response.body).to include('Free books')
     end
+
+    it_behaves_like 'it does not show global announcements'
   end
 
   describe 'GET #show' do
     let(:user) { create(:user) }
     let!(:offer) { create(:offer, name: 'Free coffee', user: user) }
 
-    context 'with a numeric id as param' do
-      before { get :show, params: { id: offer.id } }
-      
+    shared_examples 'it successfully completes the #show action' do
+      before { get :show, params: { id: offer_id } }
+
       it 'is successful' do
         expect(response).to be_successful
       end
@@ -41,22 +49,19 @@ RSpec.describe OffersController, type: :controller do
         expect(response.body).to include('Free coffee')
       end 
       
+      it_behaves_like 'it does not show global announcements'
+    end
+
+    context 'with a numeric id as param' do
+      let(:offer_id) { offer.id } 
+      
+      it_behaves_like 'it successfully completes the #show action'
     end
 
     context 'with a parameterize id' do 
-      before { get :show, params: { id: offer.to_param } }
+      let(:offer_id) { offer.to_param }
       
-      it 'is successful' do
-        expect(response).to be_successful
-      end
-
-      it 'assigns the offer' do
-        expect(assigns(:offer)).to eq(offer)
-      end
-
-      it 'renders the offer' do
-        expect(response.body).to include('Free coffee')
-      end 
+      it_behaves_like 'it successfully completes the #show action'
     end
   end
 
@@ -89,6 +94,8 @@ RSpec.describe OffersController, type: :controller do
       it 'renders form for creating an offer' do
         expect(response.body).to include('Create new resource')     
       end
+
+      it_behaves_like 'it does not show global announcements'
     end
   end
 
@@ -122,6 +129,8 @@ RSpec.describe OffersController, type: :controller do
       it 'renders form for creating an offer' do
         expect(response.body).to include("Edit resource #{offer.name}")     
       end
+
+      it_behaves_like 'it does not show global announcements'
     end
 
     context 'when admin is signed-in' do
@@ -144,6 +153,8 @@ RSpec.describe OffersController, type: :controller do
       it 'renders form for creating an offer' do
         expect(response.body).to include("Edit resource #{offer.name}")     
       end
+
+      it_behaves_like 'it does not show global announcements'
     end
   end
 
@@ -168,6 +179,8 @@ RSpec.describe OffersController, type: :controller do
         expect(response).to redirect_to(offer_path(assigns(:offer))) #Can't think of a better wato test this...
       end
     end
+
+    it_behaves_like 'it does not show global announcements'
   end
 
   describe 'PUT #update' do
@@ -191,6 +204,8 @@ RSpec.describe OffersController, type: :controller do
       it 'redirects to the offer' do
         expect(response).to redirect_to(offer_path(offer))
       end
+
+      it_behaves_like 'it does not show global announcements'
     end
 
     context 'when admin is signed in' do
@@ -227,6 +242,8 @@ RSpec.describe OffersController, type: :controller do
       it 'it redirects to the offers' do
         expect(response).to redirect_to(offers_path)
       end
+
+      it_behaves_like 'it does not show global announcements'
     end
 
     context 'when admin is signed in' do

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe OffersController, type: :controller do
     end
   end
 
-  describe 'GET #edit' do #TEST ONLY OWNER OR ADMIN, 
+  describe 'GET #edit' do
     let(:offer) { create(:offer, user: user) }
     let(:user) { create(:user) }
 
@@ -193,9 +193,8 @@ RSpec.describe OffersController, type: :controller do
         before { post :create }
 
         it 'redirects to the offer' do
-          post :create
-
-          expect(response).to redirect_to(offer_path(assigns(:offer))) #Can't think of a better wato test this...        
+          expect(response).to redirect_to(offer_path(assigns(:offer)))
+          expect(flash[:notice]).to eq('Offer was successfully created.')
         end
 
         it_behaves_like 'it does not show global announcements'
@@ -237,6 +236,7 @@ RSpec.describe OffersController, type: :controller do
 
         it 'redirects to the offer' do
           expect(response).to redirect_to(offer_path(offer))
+          expect(flash[:notice]).to eq('Offer was successfully updated.')
         end
 
         it_behaves_like 'it does not show global announcements'
@@ -289,6 +289,7 @@ RSpec.describe OffersController, type: :controller do
 
       it 'redirects to the offer' do
         expect(response).to redirect_to(offers_path)
+        expect(flash[:notice]).to eq('Offer was successfully destroyed.')
       end
     end
   end

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -32,8 +32,7 @@ RSpec.describe OffersController, type: :controller do
       expect(assigns(:offer)).to eq(offer)
     end
 
-    it 'works with a "5-my-offer-name" param too' do
-      expect(offer.to_param).to eq("#{offer.id}-#{offer.name.parameterize}")
+    it 'works with a "5-my-offer-name" param too' do #why do we need a named param if we can retrieve a resource by its id?
       get :show, params: { id: offer.to_param }
       expect(response).to be_successful
       expect(assigns(:offer)).to eq(offer)

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -1,10 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe OffersController, type: :controller do
+  render_views
+
   describe 'GET #index' do
-    it 'works' do
-      pending 'TODO'
-      fail
+    let!(:offer) { create(:offer, name: 'Free books', user: user) }
+    let(:user) { create(:user) }
+    
+    before { get :index }
+    
+    it 'is successful' do
+      expect(response).to be_successful
+    end
+
+    it 'assigns offers' do
+      expect(assigns(:offers)).to eq([offer])
+    end
+
+    it 'displays the offer' do
+      expect(response.body).to include('Free books')
     end
   end
 

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe OffersController, type: :controller do
       it_behaves_like 'it does not show global announcements'
     end
 
-    context 'with a parameterize id' do 
+    context 'with a parameterized id' do 
       let(:offer_id) { offer.to_param }
       
       it_behaves_like 'a successful request', 'Free coffee'
@@ -137,8 +137,6 @@ RSpec.describe OffersController, type: :controller do
       it 'assigns the offer' do
         expect(assigns(:offer)).to eq(offer)
       end
-
-      it_behaves_like 'it does not show global announcements'
     end
   end
 
@@ -146,7 +144,7 @@ RSpec.describe OffersController, type: :controller do
     let(:user) { create(:user) }
 
     context 'when user is not signed in' do
-      before { post :create, params: { offer: { name: 'name', description: 'desc', limitations: 'limit', redemption: 'red', location: 'loc'} } }
+      before { post :create }
 
       it_behaves_like 'an unsuccessful request'
     end
@@ -164,17 +162,15 @@ RSpec.describe OffersController, type: :controller do
           post :create
         end
 
-        it 'redirects to the new page' do
+        it 'is unsuccessful' do
           expect(response).to render_template(:new)
         end
-
-        it_behaves_like 'it does not show global announcements'
       end
 
       context 'when offer can be saved' do
         before { post :create }
 
-        it 'redirects to the offer' do
+        it 'is successful' do
           expect(response).to redirect_to(offer_path(assigns(:offer)))
           expect(flash[:notice]).to eq('Offer was successfully created.')
         end
@@ -206,17 +202,15 @@ RSpec.describe OffersController, type: :controller do
           put :update, params: params
         end
 
-        it 'renders the edit page' do
+        it 'is unsuccessful' do
           expect(response).to render_template(:edit)
         end
-
-        it_behaves_like 'it does not show global announcements'
       end
 
       context 'when offer can be updated' do
         before { put :update, params: params }
 
-        it 'redirects to the offer' do
+        it 'is successful' do
           expect(response).to redirect_to(offer_path(offer))
           expect(flash[:notice]).to eq('Offer was successfully updated.')
         end
@@ -233,7 +227,7 @@ RSpec.describe OffersController, type: :controller do
         put :update, params: { id: offer.id, name: 'a new name' }
       end
 
-      it 'redirects to the offer' do
+      it 'it is successful' do
         expect(response).to redirect_to(offer_path(offer))
       end
     end    
@@ -254,8 +248,9 @@ RSpec.describe OffersController, type: :controller do
         sign_in user
         post :destroy, params: { id: offer.id }
       end
-      it 'it redirects to the offers' do
+      it 'is successful' do
         expect(response).to redirect_to(offers_path)
+        expect(flash[:notice]).to eq('Offer was successfully destroyed.')
       end
 
       it_behaves_like 'it does not show global announcements'
@@ -269,9 +264,8 @@ RSpec.describe OffersController, type: :controller do
         post :destroy, params: { id: offer.id }
       end
 
-      it 'redirects to the offer' do
+      it 'is successful' do
         expect(response).to redirect_to(offers_path)
-        expect(flash[:notice]).to eq('Offer was successfully destroyed.')
       end
     end
   end

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe OffersController, type: :controller do
       expect(assigns(:offers)).to eq([offer])
     end
 
-    it 'displays the offer' do
+    it 'renders the offer' do
       expect(response.body).to include('Free books')
     end
   end
@@ -60,7 +60,7 @@ RSpec.describe OffersController, type: :controller do
       expect(assigns(:offer)).to be_an_instance_of(Offer)
     end
 
-    it 'displays form for creating an offer' do
+    it 'renders form for creating an offer' do
       sign_in user
 
       get :new 
@@ -90,7 +90,7 @@ RSpec.describe OffersController, type: :controller do
       expect(assigns(:offer)).to eq(offer)
     end
 
-    it 'displays form for creating an offer' do
+    it 'renders form for creating an offer' do
       sign_in user
 
       get :edit, params: { id: offer.id  }
@@ -100,9 +100,16 @@ RSpec.describe OffersController, type: :controller do
   end
 
   describe 'POST #create' do
+    let(:user) { create(:user) }
+    let(:offer) { create(:offer, user: user) }
+
+    before { allow(Offer).to receive(:new).and_return(offer)}
+
     it 'works' do
-      pending 'TODO'
-      fail
+      sign_in user
+      post :create, params: { offer: { name: offer.name, description: 'desc', limitations: 'limit', redemption: 'red', location: 'loc'} }
+
+      expect(response).to redirect_to(offer_path(assigns(:offer)))
     end
   end
 

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -11,4 +11,13 @@ RSpec.describe Offer, type: :model do
     offer = build(:offer, user: nil)
     expect(offer).to_not be_valid
   end
+
+  describe '#to_param' do
+  	let(:user) { build(:user) }
+  	let(:offer) { build(:offer, user: user) }
+
+		it 'should parameterize id' do
+			expect(offer.to_param).to eq("#{offer.id}-#{offer.name.parameterize}")
+		end
+  end
 end


### PR DESCRIPTION
This PR adds tests for each action in the OffersController.

For each action I've tested:
- authorized and unauthorized requests 
- that global announcements are not visible

Additionally, for `edit`, `update` and `destroy` I've tested that admins have access.

I've also moved one test to the `Offer` model spec as it tested a method on that model.

I have not tested changes to the db as I wasn't sure how to in this spec (plus I wasn't sure if it was necessary - still figuring out which tests sit inside the controller spec domain 🙂)