### PR TITLE
refactor project card scroll gradient for ios compatibility

### DIFF
--- a/app/frontend/styles/featured-categories.css
+++ b/app/frontend/styles/featured-categories.css
@@ -17,12 +17,7 @@
   .featured-categories { padding-top: 10% }
 }
 
-/* Scroll Affordance Gradient on Project Card Labels */
-.scroll-gradient-right:after {
-  content: "";
-  width: 1rem;
-  height: 24px;
-  position: fixed;
-  right: 1.25rem; /* set to value of Tailwind padding class,`px-5` */
+.scroll-gradient-right {
   background: linear-gradient(to left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 100%);
 }
+

--- a/app/views/projects/_project-card.html.erb
+++ b/app/views/projects/_project-card.html.erb
@@ -21,13 +21,16 @@
       <% end %>
     </div>
     <% if project.project_types.present? %>
-      <div class="relative w-full overflow-x-auto scrolling-touch scrollbar-hidden h-6 mb-4">
-        <div class="scroll-gradient-right flex flex-row flex-no-wrap flex-shrink-0 h-full flex-shrink-0 space-x-right-2">
+    <div class="relative w-full h-6 mb-4">
+      <span class="scroll-gradient-right inline-block w-4 h-6 absolute right-0 z-50"></span>
+      <div class="w-full overflow-x-auto scrolling-touch scrollbar-hidden">
+        <div class="flex flex-row flex-no-wrap flex-shrink-0 flex-shrink-0 space-x-right-2">
           <% project.project_types.each do |type| %>
             <%= filter_badge label: type %>
           <% end %>
         </div>
       </div>
+    </div>
     <% end %>
 
     <div class="relative grid grid-cols-2 gap-2 text-xs mt-3">


### PR DESCRIPTION
Fixes #194 

Removes quick and clever CSS (always gets me eventually!) in favor of a more resilient HTML structure and simple Tailwind classes. 

The issue was that `position: fixed` really doesn't play well with iOS Safari at all—and I completely forgot. 

![image](https://user-images.githubusercontent.com/1129103/80294554-db864580-871e-11ea-8a40-bef009fc2fa1.png)


