### PR TITLE
refactor project card layout to fix details spacing

### DIFF
--- a/app/views/projects/_project-card.html.erb
+++ b/app/views/projects/_project-card.html.erb
@@ -34,23 +34,24 @@
     <% end %>
 
     <div class="relative grid grid-cols-2 gap-2 text-xs mt-3">
-
-      <% total_volunteers = project.volunteers.count %>
-      <div class="font-bold">
-        <% if total_volunteers > 0 %>
-          <%= total_volunteers %> <%= 'volunteer'.pluralize total_volunteers %>
-        <% else %>
-          No volunteers
-        <% end %>
+      <div>
+        <% total_volunteers = project.volunteers.count %>
+        <div class="font-bold">
+          <% if total_volunteers > 0 %>
+            <%= total_volunteers %> <%= 'volunteer'.pluralize total_volunteers %>
+          <% else %>
+            No volunteers
+          <% end %>
+        </div>
+        <div class="text-gray-500"><%= time_ago_in_words project.created_at %> ago</div>
       </div>
-
       <% if project.volunteer_location? %>
-        <div class="text-right"><%= inline_svg_pack_tag 'media/svgs/project-card-location.svg', class: 'inline' %><%= project.volunteer_location %></div>
+        <div class="text-right leading-snug"><%= inline_svg_pack_tag 'media/svgs/project-card-location.svg', class: 'inline' %><%= project.volunteer_location %></div>
       <% end %>
 
     </div>
 
-    <div class="text-xs text-gray-500 text-left w-full"><%= time_ago_in_words project.created_at %> ago</div>
+    
 
   </div>
 <% end %>


### PR DESCRIPTION
Fixes #153 

Restructures the bottom of the card layout so the time-ago is nested under volunteer info when location wraps to two lines.

![image](https://user-images.githubusercontent.com/1129103/80294910-aa0f7900-8722-11ea-97e8-dad10d16100e.png)

(Note: this is the only country name where the second line is long enough to extend under the location icon—it looks awkward here but is an extreme corner case)