### PR TITLE
fix: countries filter is not selecting all countries

### DIFF
--- a/app/frontend/covid/covid.js
+++ b/app/frontend/covid/covid.js
@@ -132,7 +132,7 @@ const Covid = {
         this.selected = []
       },
       selectAll() {
-        this.selected = this.options.map(item => item[0])
+        this.selected = this.options.map(item => item[1])
       },
       selectedCount() {
         return this.selected.length > 0 ? this.selected.length : ''


### PR DESCRIPTION
After clicking select all on the countries filter, only global was getting selected. This fixes that.