### PR TITLE
fix: featured projects icon is misaligned

### DIFF
--- a/app/views/partials/_featured-projects.html.erb
+++ b/app/views/partials/_featured-projects.html.erb
@@ -1,4 +1,4 @@
-<div class="flex mb-4">
+<div class="flex mb-4 px-4 sm:px-0">
   <%
     project_category = Settings.project_categories.select { |cat| cat.name == category }.first
     color = project_category.present? ? project_category.color : 'indigo'


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/1334409/80455668-e0244700-8934-11ea-9245-3d4343c75a0c.png)
