### PR TITLE
Change text on button so user will click it, even if they don't have …

### DIFF
--- a/app/views/projects/_volunteer_button.html.erb
+++ b/app/views/projects/_volunteer_button.html.erb
@@ -64,7 +64,7 @@
               <path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z"/>
             </svg>
             <span>
-              Volunteers filled
+              Volunteer
             </span>
           </button>
         <% end %>


### PR DESCRIPTION
…the neccessary skills

Addresses issue: https://github.com/helpwithcovid/covid-volunteers/issues/228

A small PR to change the button text when a user does not have the correct skills for a project. Previously the button read 'Volunteers filled', indicating the project no longer needs volunteers which is untrue.

Now the button reads 'Volunteer' - and if a user clicks on it but doesn't have the right skills, a modal will pop to take them to their profile page to update their skills if they want to.

I haven't written tests for this yet..! I may do in a separate PR depending on team input around view specs/view tests in controller specs