### PR TITLE
Fixing issue related to description link

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -355,7 +355,7 @@
                 <%= project_panel_item(title: 'Helpful links') do %>
                   <div>
                     <%= simple_format (Rinku.auto_link(sanitize(@project.links), :all, 'class="text-indigo-500" rel="nofollow noopener noreferrer"') do |url|
-                      url.length > 35 ? shorten_url(url_from_string("http://#{url}")) : url
+                      url.length > 35 ? shorten_url(url_from_string(url.start_with?('http') ? url : "http://#{url}")) : url
                     end), { class: 'mb-1' }, sanitize: false %>
                   </div>
                 <% end %>


### PR DESCRIPTION
Fixing the issue related to useful links shortening
Eg: https://helpwithcovid.com/projects/833-humanner

![image](https://user-images.githubusercontent.com/496330/82286115-902c2380-99ba-11ea-8773-15b4966b0292.png)

Updated fix looks like this

![image](https://user-images.githubusercontent.com/496330/82286170-b782f080-99ba-11ea-9261-9ec9dba15b56.png)
