### PR TITLE
Redirect to previous page after profile edit

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -31,12 +31,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # GET /resource/edit
   def edit
-  	session[:return_to] ||= request.referer
+  	super
+    session[:return_to] ||= request.referer
   end
 
   # PUT /resource
   def update
-    # byebug
     super
   end
 
@@ -62,7 +62,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
     # If you have extra params to permit, append them to the sanitizer.
     def configure_account_update_params
-      devise_parameter_sanitizer.permit(:account_update, keys: [ :name, :about, :profile_links, :location, :visibility, :pair_with_projects,  :level_of_availability, skill_list: []])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:name, :about, :profile_links, :location, :visibility, :pair_with_projects,  :level_of_availability, skill_list: []])
     end
 
     # The path used after sign up.
@@ -92,7 +92,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
     end
 
     def after_update_path_for(resource)
-    	session.delete(:return_to)
+      session.delete(:return_to)
     end
-
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -30,14 +30,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   # GET /resource/edit
-  # def edit
-  #   super
-  # end
+  def edit
+  	session[:return_to] ||= request.referer
+  end
 
   # PUT /resource
-  # def update
-  #   super
-  # end
+  def update
+    # byebug
+    super
+  end
 
   # DELETE /resource
   # def destroy
@@ -89,4 +90,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
       return 'created_at desc' if params[:sort_by] == 'latest'
       return 'created_at asc' if params[:sort_by] == 'earliest'
     end
+
+    def after_update_path_for(resource)
+    	session.delete(:return_to)
+    end
+
 end

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -283,4 +283,36 @@ RSpec.describe Users::RegistrationsController, type: :controller do
       end
     end
   end
+
+  describe 'PUT #update' do
+    let!(:user) { create(:user) }
+    let(:params) { { id: '1982738917269816' } }
+    # let(:real_params) { { "user"=>{"name"=>"something", "about"=>"somethi", "skill_list"=>["Analytics"], 
+    #   "level_of_availability"=>"1-2 hours a day", "profile_links"=>"s", "location"=>"someth", 
+    #   "visibility"=>"0", "pair_with_projects"=>"0", "email"=>"cat@gmail.com", 
+    #   "password"=>"", "password_confirmation"=>"", "current_password"=>""} } }
+
+    before do
+      sign_in user
+    end
+
+    it 'we should be on projects path' do
+      put :update, params: params
+
+      expect(user.email).to eq('newemail@gmail.com')
+    end
+
+    # it 'redirects to previous page' do
+    #   put :update, params: params, session: { return_to: volunteers_path }
+    #   expect(response).to redirect_to volunteers_path
+    # end
+  end
 end
+
+    # <ActionController::Parameters {"_method"=>"put", 
+    # "authenticity_token"=>"Yh3ojJLMOoiWH4wROxI6lMi9PGTHBlCMmyu4ZbWousJ0o+wMTXpXsC1VbRTJ/Gd4Qb2589yxzfojb5G0ZB5Syg==", 
+    # "user"=>{"name"=>"something", "about"=>"somethi", "skill_list"=>["Analytics"], 
+    #   "level_of_availability"=>"1-2 hours a day", "profile_links"=>"s", "location"=>"someth", 
+    #   "visibility"=>"0", "pair_with_projects"=>"0", "email"=>"cat@gmail.com", 
+    #   "password"=>"", "password_confirmation"=>"", "current_password"=>""}, 
+    #   "controller"=>"users/registrations", "action"=>"update"} permitted: false>

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -285,34 +285,26 @@ RSpec.describe Users::RegistrationsController, type: :controller do
   end
 
   describe 'PUT #update' do
-    let!(:user) { create(:user) }
-    let(:params) { { id: '1982738917269816' } }
-    # let(:real_params) { { "user"=>{"name"=>"something", "about"=>"somethi", "skill_list"=>["Analytics"], 
-    #   "level_of_availability"=>"1-2 hours a day", "profile_links"=>"s", "location"=>"someth", 
-    #   "visibility"=>"0", "pair_with_projects"=>"0", "email"=>"cat@gmail.com", 
-    #   "password"=>"", "password_confirmation"=>"", "current_password"=>""} } }
+    let!(:user) { create(:user_complete_profile) }
+    let(:params) { { user: { id: user.id, email: 'changed@gmail.com' } } }
 
     before do
       sign_in user
+      session[:return_to] = projects_path
     end
 
     it 'we should be on projects path' do
       put :update, params: params
-
-      expect(user.email).to eq('newemail@gmail.com')
+      
+      user.reload
+      expect(user.email).to eq('changed@gmail.com')
     end
 
-    # it 'redirects to previous page' do
-    #   put :update, params: params, session: { return_to: volunteers_path }
-    #   expect(response).to redirect_to volunteers_path
-    # end
+    it 'should redirect to return_to cookie path' do
+      put :update, params: params
+
+      expect(response).to redirect_to projects_path
+    end
+
   end
 end
-
-    # <ActionController::Parameters {"_method"=>"put", 
-    # "authenticity_token"=>"Yh3ojJLMOoiWH4wROxI6lMi9PGTHBlCMmyu4ZbWousJ0o+wMTXpXsC1VbRTJ/Gd4Qb2589yxzfojb5G0ZB5Syg==", 
-    # "user"=>{"name"=>"something", "about"=>"somethi", "skill_list"=>["Analytics"], 
-    #   "level_of_availability"=>"1-2 hours a day", "profile_links"=>"s", "location"=>"someth", 
-    #   "visibility"=>"0", "pair_with_projects"=>"0", "email"=>"cat@gmail.com", 
-    #   "password"=>"", "password_confirmation"=>"", "current_password"=>""}, 
-    #   "controller"=>"users/registrations", "action"=>"update"} permitted: false>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -35,7 +35,7 @@ FactoryBot.define do
     about { 'About' }
     profile_links { 'Profile' }
     location { 'location' }
-    skill_list { ['Analaytics'] }
+    skill_list { ['Analytics'] }
   end
 
   factory :project do


### PR DESCRIPTION
Addresses https://github.com/helpwithcovid/covid-volunteers/issues/244

cc pairing buddy: @cooknat

When a user is on a page (eg '/projects') and then they go to their profile page and edit it, when they hit save changes, they are taken back to the last page they were on (in this case '/projects')