### PR TITLE
Remove labels for projects that show when they were created

### DIFF
--- a/app/views/projects/_project-card.html.erb
+++ b/app/views/projects/_project-card.html.erb
@@ -43,7 +43,6 @@
             <%= t('no_volunteers') %>
           <% end %>
         </div>
-        <div class="text-gray-500"><%= time_ago_in_words project.created_at %> ago</div>
       </div>
       <% if project.volunteer_location? %>
         <div class="text-right leading-snug"><%= inline_svg_pack_tag 'media/svgs/project-card-location.svg', class: 'inline' %><%= project.volunteer_location %></div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -209,10 +209,6 @@
               </span>
             </div>
             <div class="flex items-center text-primary-600 col-span-1">
-              <%= inline_svg_pack_tag 'media/svgs/time-ago.svg', class: 'h-6 mr-2 text-primary-600 fill-current' %>
-              <span class="text-gray-500 text-xs font-bold leading-tight">Created <%= time_ago_in_words(@project.created_at) %> ago</span>
-            </div>
-            <div class="flex items-center text-primary-600 col-span-1">
               <%= inline_svg_pack_tag 'media/svgs/people.svg', class: 'h-6 mr-2 text-primary-600 fill-current' %>
               <span class="text-gray-500 text-xs font-bold leading-tight"><%= @project.volunteers.count %> <%= 'Volunteer'.pluralize @project.volunteers.count %></span>
             </div>


### PR DESCRIPTION
This PR removes the 'created at' label from project views.

Further context: https://trello.com/c/9g9LdxXQ/4-remove-timelapsed-label