### PR TITLE
Create rake task for importing businesses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,3 +109,7 @@ gem 'iso_country_codes', '~> 0.7.8'
 
 # JS Translations
 gem 'i18n-js'
+
+# Importing CSVs
+gem 'csv'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
     crass (1.0.6)
+    csv (3.1.7)
     deep_merge (1.2.1)
     devise (4.7.1)
       bcrypt (~> 3.0)
@@ -388,6 +389,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   config
+  csv
   devise
   dotenv-rails
   exception_notification!

--- a/lib/tasks/import_businesses_from_csv.rake
+++ b/lib/tasks/import_businesses_from_csv.rake
@@ -1,0 +1,17 @@
+require 'csv'
+require 'open-uri'
+
+desc 'Import CSVs with business data into Projects table'
+#example command: rake import_csv['https://a_csv.csv','A project type']
+task :import_csv, [:path, :tag] => :environment do |task, args|
+  csv_text = open(args[:path])
+  csv = CSV.parse(csv_text, :headers=>true)
+  csv.each do |row|
+  	converted_row = row.to_hash
+  	converted_row[:project_type_list] = [ args[:tag] ]
+  	Project.create!(converted_row)
+  end
+end
+
+
+

--- a/lib/tasks/import_businesses_from_csv.rake
+++ b/lib/tasks/import_businesses_from_csv.rake
@@ -2,13 +2,14 @@ require 'csv'
 require 'open-uri'
 
 desc 'Import CSVs with business data into Projects table'
-#example command: rake import_csv['https://a_csv.csv','A project type']
-task :import_csv, [:path, :tag] => :environment do |task, args|
+#example command: rake import_csv['https://a_csv.csv','Food & Beverage',7]
+task :import_csv, [:path, :tag, :user_id] => :environment do |task, args|
   csv_text = open(args[:path])
   csv = CSV.parse(csv_text, :headers=>true)
   csv.each do |row|
   	converted_row = row.to_hash
   	converted_row[:project_type_list] = [ args[:tag] ]
+  	converted_row[:user_id] = args[:user_id]
   	Project.create!(converted_row)
   end
 end


### PR DESCRIPTION
We require a number of businesses to be imported into our db for a demo of HWBE to potential users.

This PR adds a rake task that takes two parameters: a remote csv url and a project type. It then populates the Project db with a list of businesses from the csv and tags them with the given project type.

I expect this rake task to be here only temporarily to add businesses quickly before the demo. I have put up a Trello card to delete it after this week: https://trello.com/c/t9Uc2mXK/39-remove-rake-task