### PR TITLE
Add example new category color

### DIFF
--- a/app/models/concerns/has_cover_photo.rb
+++ b/app/models/concerns/has_cover_photo.rb
@@ -1,4 +1,3 @@
-
 module HasCoverPhoto
   extend ActiveSupport::Concern
   included do

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,6 @@ try {
 let themeColors = {
   primary: uiColors.indigo,
   secondary: uiColors.purple,
-  'cat-foobar': '#ffffff'
 }
 
 // adding accent colors
@@ -34,6 +33,11 @@ themeColors.accent = {
   sub_navbar_text: uiColors.black.default,
   filters_navbar_bg: themeColors.primary[100],
   filters_navbar_text: uiColors.black.default,
+}
+
+themeColors = {
+  ...themeColors,
+  ...themeConfig.colors.categories,
 }
 
 // Parsing the theme config
@@ -71,11 +75,6 @@ module.exports = {
         ...themeColors,
         smoke: 'rgba(0, 0, 0, 0.5)',
         'hero-black': '#3D3D3D',
-        'cat-education': '#F82B2B',
-        'cat-social-justice': '#FD813B',
-        'cat-business-directory': '#8921DC',
-        'cat-health': '#2987DE',
-        'cat-wealth': '#12CFA1',
       },
       maxHeight: {
         '400px': '400px',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,7 @@ try {
 let themeColors = {
   primary: uiColors.indigo,
   secondary: uiColors.purple,
-  'cat-foobar': '#0800ff'
+  'cat-foobar': '#ffffff'
 }
 
 // adding accent colors

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,6 +19,7 @@ try {
 let themeColors = {
   primary: uiColors.indigo,
   secondary: uiColors.purple,
+  'cat-foobar': '#0800ff'
 }
 
 // adding accent colors
@@ -67,16 +68,8 @@ module.exports = {
         '2px': '2px',
       },
       colors: {
+        ...themeColors,
         smoke: 'rgba(0, 0, 0, 0.5)',
-        primary: {
-          ...themeColors.primary,
-        },
-        secondary: {
-          ...themeColors.secondary,
-        },
-        accent: {
-          ...themeColors.accent,
-        },
         'hero-black': '#3D3D3D',
         'cat-education': '#F82B2B',
         'cat-social-justice': '#FD813B',

--- a/theme/settings.yml
+++ b/theme/settings.yml
@@ -31,7 +31,7 @@ project_categories:
       - College affordability
       - STEM
       - Support HBCU’s
-    color: cat-education
+    color: cat-foobar
   - name: Social Justice
     slug: social-justice
     body: Directly impact social inequalities

--- a/theme/tailwind.config.yml
+++ b/theme/tailwind.config.yml
@@ -12,4 +12,9 @@ colors:
     sub_navbar_text: '#ffffff'
     filters_navbar_bg: '#3D3D3D'
     filters_navbar_text: '#ffffff'
-  'cat-foobar': '#0800ff'
+  categories:
+    cat-education: '#F82B2B'
+    cat-social-justice: '#FD813B'
+    cat-business-directory: '#8921DC'
+    cat-health: '#2987DE'
+    cat-wealth: '#12CFA1'

--- a/theme/tailwind.config.yml
+++ b/theme/tailwind.config.yml
@@ -12,3 +12,4 @@ colors:
     sub_navbar_text: '#ffffff'
     filters_navbar_bg: '#3D3D3D'
     filters_navbar_text: '#ffffff'
+  'cat-foobar': '#0800ff'


### PR DESCRIPTION
I'm trying to use our theming implementation to allow me to add a new color for use throughout the website. The reason being that HWBE will have new categories and they will need new colors.

I've attempted to add a new category color `cat-foobar` to the HWBE theme. As a test, I changed the Settings file, so that the category `Education` now uses the color `cat-foobar`. I added the `'cat-foobar': '#0800ff'` to the `theme/tailwind.config.yml` file, but it didn't work.

In order to get it to work, I had to add ``'cat-foobar': '#0800ff'`` to the the global tailwind file (ie `tailwind.config.js`). It seems like in order to add a color (eg `cat-foobar`) to HWBE, we need to declare the came color in our global tailwind file. Once `cat-foobar` is decalred in the global tailwind file, I can override it with whatever color I want in the `theme/tailwind.config.yml` file

This poses a problem as it means I have to declare HWBE-specific colors in the global Tailwind file, which negates the whole point of our themeing implementation.

I could of course be going about this the wrong way 😅 . I've made this PR to help illustrate what I mean (see code comments below).

