### PR TITLE
fix: locale regex

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -120,7 +120,7 @@ class ApplicationController < ActionController::Base
 
     def extract_locale_from_accept_language_header
       return nil if request.env['HTTP_ACCEPT_LANGUAGE'].blank?
-      request.env['HTTP_ACCEPT_LANGUAGE'].scan(/^[a-z]{2}/).first
+      request.env['HTTP_ACCEPT_LANGUAGE'].scan(/^[a-z]{2}-[A-Z]{2}/).first
     end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -115,12 +115,16 @@ class ApplicationController < ActionController::Base
       logger.debug "* Locale: overriding with ?locale param=#{params[:locale].inspect}" if params[:locale].present?
       logger.debug "* Locale: HTTP Accept-Language: #{extract_locale_from_accept_language_header.inspect}" if extract_locale_from_accept_language_header.present?
       logger.info "* Locale set to #{locale.inspect}"
-      I18n.with_locale(locale, &action)
+      begin
+        I18n.with_locale(locale, &action)
+      rescue => exception
+        I18n.with_locale(I18n.default_locale, &action)
+      end
     end
 
     def extract_locale_from_accept_language_header
       return nil if request.env['HTTP_ACCEPT_LANGUAGE'].blank?
-      request.env['HTTP_ACCEPT_LANGUAGE'].scan(/^[a-z]{2}-[A-Z]{2}/).first
+      request.env['HTTP_ACCEPT_LANGUAGE'].scan(/^[a-z]{2}/).first
     end
 
 end


### PR DESCRIPTION
The locale regex only pulls up two letters `ro` and it seems it's not a valid locale.

This update fixes it to pick up `ro-RO`.

<details>
<summary>Error</summary>

```
An I18n::InvalidLocale occurred in projects#index:
2020-08-25T16:30:09.593225+00:00 app[web.1]:
2020-08-25T16:30:09.593226+00:00 app[web.1]: "ro" is not a valid locale
2020-08-25T16:30:09.593226+00:00 app[web.1]: app/controllers/application_controller.rb:118:in `switch_locale'
2020-08-25T16:30:09.593226+00:00 app[web.1]:
2020-08-25T16:30:09.593227+00:00 app[web.1]:
2020-08-25T16:30:09.593227+00:00 app[web.1]: -------------------------------
2020-08-25T16:30:09.593228+00:00 app[web.1]: Request:
2020-08-25T16:30:09.593228+00:00 app[web.1]: -------------------------------
2020-08-25T16:30:09.593228+00:00 app[web.1]:
2020-08-25T16:30:09.593229+00:00 app[web.1]: * URL        : https://www.helpwithblackequity.com/favicon.ico
2020-08-25T16:30:09.593229+00:00 app[web.1]: * HTTP Method: GET
2020-08-25T16:30:09.593230+00:00 app[web.1]: * IP address : 86.123.198.107
2020-08-25T16:30:09.593230+00:00 app[web.1]: * Parameters : {"controller"=>"projects", "action"=>"index", "category_slug"=>"favicon", "format"=>"ico"}
2020-08-25T16:30:09.593231+00:00 app[web.1]: * Timestamp  : 2020-08-25 09:30:09 -0700
2020-08-25T16:30:09.593231+00:00 app[web.1]: * Server : 1ccec1b7-2aa6-4158-8f90-a2c27bc8b6dd
2020-08-25T16:30:09.593231+00:00 app[web.1]: * Rails root : /app
2020-08-25T16:30:09.593232+00:00 app[web.1]: * Process: 4
2020-08-25T16:30:09.593232+00:00 app[web.1]:
2020-08-25T16:30:09.593232+00:00 app[web.1]: -------------------------------
2020-08-25T16:30:09.593233+00:00 app[web.1]: Session:
2020-08-25T16:30:09.593233+00:00 app[web.1]: -------------------------------
2020-08-25T16:30:09.593233+00:00 app[web.1]:
2020-08-25T16:30:09.593234+00:00 app[web.1]: * session id: [FILTERED]
2020-08-25T16:30:09.593234+00:00 app[web.1]: * data: {}
2020-08-25T16:30:09.593234+00:00 app[web.1]:
2020-08-25T16:30:09.593235+00:00 app[web.1]: -------------------------------
2020-08-25T16:30:09.593235+00:00 app[web.1]: Environment:
2020-08-25T16:30:09.593235+00:00 app[web.1]: -------------------------------
2020-08-25T16:30:09.593235+00:00 app[web.1]:
2020-08-25T16:30:09.593236+00:00 app[web.1]: * GATEWAY_INTERFACE                                       : CGI/1.2
2020-08-25T16:30:09.593236+00:00 app[web.1]: * HTTP_ACCEPT                                             : image/webp,image/apng,image/*,*/*;q=0.8
2020-08-25T16:30:09.593237+00:00 app[web.1]: * HTTP_ACCEPT_ENCODING                                    : gzip, deflate, br
2020-08-25T16:30:09.593237+00:00 app[web.1]: * HTTP_ACCEPT_LANGUAGE                                    : ro-RO,ro;q=0.9,en-US;q=0.8,en;q=0.7
```
</details>
