### PR TITLE
Add source column to Project

### DIFF
--- a/db/migrate/20200831152954_add_source_to_projects.rb
+++ b/db/migrate/20200831152954_add_source_to_projects.rb
@@ -1,0 +1,5 @@
+class AddSourceToProjects < ActiveRecord::Migration[6.0]
+  def change
+  	add_column :projects, :source, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_15_100213) do
+ActiveRecord::Schema.define(version: 2020_08_31_152954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 2020_08_15_100213) do
     t.decimal "longitude"
     t.decimal "latitude"
     t.boolean "multiple_locations"
+    t.string "source"
   end
 
   create_table "success_stories", force: :cascade do |t|


### PR DESCRIPTION
We may want to know where imported businesses have been imported from.

Add a `source` column to `Project` to capture this info.

Further context: https://trello.com/c/FIPjw6ev/66-add-column-needsfunding-to-projects