### PR TITLE
Amend rake import_csv task to include source arg

### DIFF
--- a/lib/tasks/import_businesses_from_csv.rake
+++ b/lib/tasks/import_businesses_from_csv.rake
@@ -2,14 +2,15 @@ require 'csv'
 require 'open-uri'
 
 desc 'Import CSVs with business data into Projects table'
-#example command: rake import_csv['https://a_csv.csv','Food & Beverage',7]
-task :import_csv, [:path, :tag, :user_id] => :environment do |task, args|
+#example command: rake import_csv['https://a_csv.csv','Food & Beverage',99999,'Help Main Street']
+task :import_csv, [:path, :tag, :user_id, :source] => :environment do |task, args|
   csv_text = open(args[:path])
   csv = CSV.parse(csv_text, :headers=>true)
   csv.each do |row|
   	converted_row = row.to_hash
   	converted_row[:project_type_list] = [ args[:tag] ]
   	converted_row[:user_id] = args[:user_id]
+  	converted_row[:source] = args[:source]
   	Project.create!(converted_row)
   end
 end


### PR DESCRIPTION
When importing businesses, we need to include info on where we are importing the businesses from.

This PR allows us to include a source argument to the import_csv rake task.

Further context: https://trello.com/c/tJALrsZa/67-update-rake-task-to-include-source