### PR TITLE
Change filter to only show needs_funding, remove unused filter code f…

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -178,6 +178,7 @@ class ProjectsController < ApplicationController
       @projects = @projects.where(needs_funding: params[:needs_funding]) if params[:needs_funding].present?
       @projects = @projects.tagged_with(params[:project_types], any: true, on: :project_types) if params[:project_types].present?
 
+      @projects = @projects.includes(:project_types)
       @projects = @projects.search(params[:query]) if params[:query].present?
     end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -175,39 +175,10 @@ class ProjectsController < ApplicationController
       @applied_filters = {}
 
       @projects = Project
-      @projects = @projects.tagged_with(params[:skills], any: true, on: :skills) if params[:skills].present?
+      @projects = @projects.where(needs_funding: params[:needs_funding]) if params[:needs_funding].present?
       @projects = @projects.tagged_with(params[:project_types], any: true, on: :project_types) if params[:project_types].present?
-      @projects = @projects.tagged_with(params[:for_profit_type], any: true, on: :for_profit_type) if params[:for_profit_type].present?
-      @projects = @projects.where(accepting_volunteers: params[:accepting_volunteers] == '1') if params[:accepting_volunteers].present?
-      @projects = @projects.where(highlight: true) if params[:highlight].present?
-      @projects = @projects.where(target_country: params[:target_country]) if params[:target_country].present?
-      @projects = @projects.where(status: params[:status]) if params[:status].present?
 
-      if params[:query].present?
-        @projects = @projects.search(params[:query]).left_joins(:volunteers).reorder(nil).group(:id)
-      else
-        @projects = @projects.left_joins(:volunteers).group(:id)
-      end
-
-      if params[:sort_by]
-        @projects = @projects.order(get_order_param)
-      else
-        @projects = @projects.order('highlight DESC, COUNT(volunteers.id) DESC, created_at DESC')
-      end
-
-      if params[:project_types].present?
-        @applied_filters[:project_types] = params[:project_types]
-      end
-
-      if params[:for_profit_type].present?
-        @applied_filters[:for_profit_type] = params[:for_profit_type]
-      end
-
-      if params[:skills].present?
-        @applied_filters[:skills] = params[:skills]
-      end
-
-      @projects = @projects.includes(:project_types, :skills, :volunteers)
+      @projects = @projects.search(params[:query]) if params[:query].present?
     end
 
     def ensure_no_legacy_filtering

--- a/app/views/projects/_filter-bar-filter.html.erb
+++ b/app/views/projects/_filter-bar-filter.html.erb
@@ -6,10 +6,6 @@
     <div class="absolute left-0 mt-2 p-4 bg-white z-30 shadow-lg w-full sm:w-48 flex flex-col">
       <div class="bg-white mb-2">
         <div class="font-semibold uppercase text-xs mb-1"><%= t('select') %></div>
-        <div class="flex">
-          <button class="button button-sm w-1/2 mb-2 mr-2" @click="selectAll()"><%= t('all') %></button>
-          <button class="button button-sm w-1/2 mb-2" @click="resetFilters()"><%= t('none') %></button>
-        </div>
         <button class="button button-primary w-full mb-2" @click="applyFilters()"><%= t('apply_filters') %></button>
       </div>
       <div class="relative overflow-auto max-h-400px scroll-shadow">

--- a/app/views/projects/_filter-bar-filter.html.erb
+++ b/app/views/projects/_filter-bar-filter.html.erb
@@ -5,7 +5,11 @@
   <template x-if="open">
     <div class="absolute left-0 mt-2 p-4 bg-white z-30 shadow-lg w-full sm:w-48 flex flex-col">
       <div class="bg-white mb-2">
-        <div class="font-semibold uppercase text-xs mb-1"><%= t('select') %></div>
+        <div class="font-semibold uppercase text-xs mb-1"><%= t('select') %></div>    
+        <div class="flex">
+          <button class="button button-sm w-1/2 mb-2 mr-2" @click="selectAll()"><%= t('all') %></button>
+          <button class="button button-sm w-1/2 mb-2" @click="resetFilters()"><%= t('none') %></button>
+        </div>
         <button class="button button-primary w-full mb-2" @click="applyFilters()"><%= t('apply_filters') %></button>
       </div>
       <div class="relative overflow-auto max-h-400px scroll-shadow">

--- a/app/views/projects/_filters-bar.html.erb
+++ b/app/views/projects/_filters-bar.html.erb
@@ -4,21 +4,7 @@
       <div class="font-bold mb-2 lg:mb-0 sm:mr-4"><%= t('filter_by') %></div>
       <div class="flex flex-col sm:flex-row w-full lg:w-auto">
         <div class="flex-1 lg:flex-none mb-2 w-full md:w-auto sm:mb-0 sm:mr-4 md:mb-0 sm:w-auto">
-          <%= filter_bar_filter 'Project Types', :project_types, Settings.project_types.map { |o| [o, o] } %>
-        </div>
-        <% if feature_enabled? 'for_profit_projects' %>
-          <div class="flex-1 lg:flex-none mb-2 w-full md:w-auto sm:mb-0 sm:mr-4 md:mb-0 sm:w-auto">
-            <%= filter_bar_filter 'For profit', :for_profit_type, Settings.for_profit_types.map { |o| [o, o] } %>
-          </div>
-        <% end %>
-        <div class="flex-1 lg:flex-none mb-2 w-full md:w-auto sm:mb-0 sm:mr-4 md:mb-0 sm:w-auto">
-          <%= filter_bar_filter 'Skills', :skills, Settings.volunteer_skills.map { |o| [o, o] } %>
-        </div>
-        <div class="flex-1 lg:flex-none mb-2 w-full md:w-auto sm:mb-0 sm:mr-4 md:mb-0 sm:w-auto">
-          <%= filter_bar_filter 'Countries', :target_country, get_present_country_fields %>
-        </div>
-        <div class="flex-1 lg:flex-none mb-2 w-full md:w-auto sm:mb-0 md:mb-0 sm:w-auto">
-          <%= filter_bar_filter 'Status', :status, Settings.project_statuses.map { |o| [o, o] }  %>
+          <%= filter_bar_filter 'Needs funding', :needs_funding, [['yes', 'true'], ['no', 'false']] %>
         </div>
       </div>
     </div>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -6,6 +6,7 @@
 
 <div class="container">
   <%= render partial: 'category-info' if is_projects_path %>
+  <%= render partial: 'filters-bar' if @show_filters %>
   
 
   <% if @projects.present? %>

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -22,6 +22,60 @@ RSpec.describe ProjectsController, type: :controller do
       expect(json[0]['description']).to be_present
       expect(json[0]['to_param']).to be_present
     end
+
+    context 'when searching' do
+      let!(:project) { create(:project, user: user, name: 'amazon') }
+      let!(:project_two) { create(:project, user: user, name: 'dell') }
+
+      before { get :index, params: { query: 'amazon' } }
+
+      it 'works' do
+        expect(response).to be_successful
+        expect(response.body).to include('amazon')
+        expect(response.body).to_not include('dell')
+      end
+    end
+
+    context 'when filtering' do
+      let!(:project) { create(:project, user: user, needs_funding: false, name: 'amazon') }
+      let!(:project_two) { create(:project, user: user, needs_funding: true, name: 'dell') }      
+
+      before { get :index, params: params }
+
+      context 'by projects that need funding' do
+        let(:params) { { needs_funding: true } }
+        
+        it 'works' do
+          expect(response.body).to include('dell')
+          expect(response.body).to_not include('amazon')
+        end
+      end
+
+      context 'by projects that do not need funding' do
+        let(:params) { { needs_funding: false } }
+
+        it 'works' do
+          expect(response.body).to include('amazon')
+          expect(response.body).to_not include('dell')
+        end
+      end
+    end
+
+    context 'when searching' do
+      let!(:project_two) { create(:project, user: user, name: 'dell') }
+
+      before do
+        project.update_attribute(:name, 'amazon')
+      end
+
+      it 'works' do
+        get :index, params: { query: 'amazon' }
+        
+        expect(response).to be_successful
+        expect(response.body).to include('amazon')
+        expect(response.body).to_not include('dell')
+      end
+    end
   end
 
   describe 'GET #show' do

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -22,41 +22,6 @@ RSpec.describe ProjectsController, type: :controller do
       expect(json[0]['description']).to be_present
       expect(json[0]['to_param']).to be_present
     end
-
-    describe 'Volunteering' do
-      let!(:no_volunteers_project) { create(:project, user: user, accepting_volunteers: false) }
-
-      it 'filters by ?accepting_volunteers=0' do
-        get :index, params: { accepting_volunteers: '0' }
-        expect(response).to be_successful
-        expect(assigns(:projects)).to include(no_volunteers_project)
-        expect(assigns(:projects)).to_not include(project)
-      end
-
-      it 'filters by ?accepting_volunteers=1' do
-        get :index, params: { accepting_volunteers: '1' }
-        expect(response).to be_successful
-        expect(assigns(:projects)).to_not include(no_volunteers_project)
-        expect(assigns(:projects)).to include(project)
-      end
-
-      it 'shows projects filtered by status' do
-        project.update_attribute(:status, Settings.project_statuses.last)
-        project2 = create(:project, user: user, status: Settings.project_statuses.first)
-        get :index, params: { status: Settings.project_statuses.last }
-        expect(assigns(:projects)).to include(project)
-        expect(assigns(:projects)).to_not include(project2)
-      end
-    end
-
-    it 'shows highlighted projects only' do
-      project.update_attribute(:highlight, true)
-      reg_project = create(:project, user: user, highlight: false)
-      get :index, params: { highlight: true }
-      expect(response).to be_successful
-      expect(assigns(:projects)).to include(project)
-      expect(assigns(:projects)).to_not include(reg_project)
-    end
   end
 
   describe 'GET #show' do

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -60,22 +60,6 @@ RSpec.describe ProjectsController, type: :controller do
         end
       end
     end
-
-    context 'when searching' do
-      let!(:project_two) { create(:project, user: user, name: 'dell') }
-
-      before do
-        project.update_attribute(:name, 'amazon')
-      end
-
-      it 'works' do
-        get :index, params: { query: 'amazon' }
-        
-        expect(response).to be_successful
-        expect(response.body).to include('amazon')
-        expect(response.body).to_not include('dell')
-      end
-    end
   end
 
   describe 'GET #show' do


### PR DESCRIPTION
…rom Projects controller

This PR introduces new filter attributes that we want to filter `Projects` (ie businesses) by, and also removes some carried-over attribute filters from HWC that we want to get rid of.

Specs for search and filter will both come in separate PR.

Addresses card: https://trello.com/b/02pu7vmj/the-helpwith-foundation

