### PR TITLE
Move about link on hompepage from footer to header

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,6 +39,10 @@ module ApplicationHelper
     end
   end
 
+  def about_nav_link_class(variant = 'DESKTOP')
+    params[:controller] == 'home' && params[:action] == 'about' ? nav_link_active_class(variant) : nav_link_inactive_class(variant)
+  end
+  
   def all_projects_nav_link_class(variant = 'DESKTOP')
     params[:controller] == 'projects' && params[:action] == 'index' ? nav_link_active_class(variant) : nav_link_inactive_class(variant)
   end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -2,7 +2,6 @@
   <div class="container px-5 py-7">
     <div class="flex flex-grow flex-col sm:flex-row justify-between text-sm text-gray-800">
       <div class="">
-        <%= link_to "About", about_path, class: 'font-bold mr-6' %>
         <%= link_to "Fork me on GitHub", "https://github.com/helpwithcovid/covid-volunteers", class: 'font-bold mr-6', target: :_blank %>
         <span>Part of <%= link_to "HelpWith Foundation", "https://joinhelpwith.com", class: 'font-bold mr-6', target: :_blank %></span>
       </div>

--- a/theme/views/layouts/_nav_links.html.erb
+++ b/theme/views/layouts/_nav_links.html.erb
@@ -1,3 +1,7 @@
+<%= link_to about_path, class: "#{about_nav_link_class(variant)}" do %>
+  <%= t('about') %>
+<% end %>
+
 <%= link_to projects_path, class: "#{all_projects_nav_link_class(variant)}" do %>
   <%= t('business_directory') %>
 <% end %>


### PR DESCRIPTION
This PR moves the link for the About page from the footer to the header.

Further context: https://trello.com/c/v0vMTpnx/69-misa-changes